### PR TITLE
Add smart-search runtime to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,8 @@ USER ${LILAC_USER}
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # bun (user-level)
 RUN curl -fsSL https://bun.sh/install | bash
+# smart-search (official npm package; bootstraps its isolated Python runtime)
+RUN npm install -g @konbakuyomu/smart-search@latest
 USER root
 
 ############################

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you already know upstream Lilac, start here. This fork keeps the same Bun wor
 | GitHub issue/PR comments | `/lilac` and `@bot` triggers are parsed from the first non-empty, non-quoted, non-code-fenced content line. Agent-authored comments are marked with `<!-- lilac:agent-comment -->` and ignored by webhook ingress. | Users can invoke the agent from GitHub comments more predictably, while avoiding self-trigger loops. |
 | GitHub surface output | GitHub comments created by the adapter, output stream, or `surface.messages.send` are automatically marked as agent comments. | Outbound GitHub replies remain machine-identifiable across both runtime output and tool-driven messages. |
 | ACP controller robustness | Detached ACP runs treat Linux zombie worker processes as dead, and cancellation closes the harness client so workers can settle instead of hanging indefinitely. | Long-running local/automation prompt workflows recover more cleanly from stuck harness transports. |
-| Container delivery | GitHub Actions build and publish GHCR images for `catalina` and `claudia` variants, with `latest` pointing at the `catalina` image. The Docker image also includes `rsync`. | Operators can consume prebuilt images and have a more complete shell toolbox inside the runtime container. |
+| Container delivery | GitHub Actions build and publish GHCR images for `catalina` and `claudia` variants, with `latest` pointing at the `catalina` image. The Docker image also includes `rsync` and the upstream `smart-search` CLI runtime. | Operators can consume prebuilt images and have a more complete shell toolbox plus an official `smart-search` runtime inside the container. |
 | Upstream maintenance | A scheduled GitHub Actions workflow checks `stanley2058/lilac-mono` every 6 hours and merges upstream `main` when possible, then triggers image rebuilds. | This fork is intended to stay close to upstream while keeping local operational patches visible. |
 
 The fork-specific code is intentionally small and easy to audit. Useful entry points are `apps/core/src/github/github-comment-marker.ts`, `apps/core/src/github/webhook/github-webhook-server.ts`, `apps/core/src/surface/github/`, `apps/acp-controller/controller.ts`, and `.github/workflows/`.
@@ -141,6 +141,28 @@ docker compose up --build
 ```
 
 This container path is real, but it is an operator workflow rather than a zero-config quick start. The runtime expects Redis plus runtime configuration such as surface credentials.
+
+### `smart-search` runtime in the image
+
+The runtime container installs the official `@konbakuyomu/smart-search` npm package during image build. That package creates and manages its own isolated Python runtime as part of its upstream install flow, so the image does not need a custom wrapper layer for basic CLI availability.
+
+The image already includes the upstream prerequisites that `smart-search` expects, including `nodejs`, `npm`, `python3`, `python3-pip`, and `python3-venv`.
+
+Because the container sets `XDG_CONFIG_HOME=${DATA_DIR}/.config`, the default `smart-search` config path resolves inside the runtime data directory, typically:
+
+```bash
+/data/.config/smart-search/config.json
+```
+
+Useful checks inside the container:
+
+```bash
+smart-search --version
+smart-search doctor --format json
+smart-search setup
+```
+
+If you persist `/data`, the `smart-search` config and provider credentials persist with it.
 
 ## Operational Prerequisites
 


### PR DESCRIPTION
## Summary
- install the official `@konbakuyomu/smart-search` npm package in the runtime image
- rely on the existing container prerequisites already present in this fork (`nodejs`, `npm`, `python3`, `python3-pip`, `python3-venv`)
- document smart-search runtime availability and config persistence in the repo README

## Details
This keeps the integration intentionally minimal and aligned with upstream smart-search packaging:
- no custom wrapper layer
- no plugin wiring yet
- no extra image-specific bootstrap beyond the official npm install flow

The package bootstraps its own isolated Python runtime during installation, which is exactly the behavior upstream documents.

## Validation
- verified upstream package install flow separately with `npm install @konbakuyomu/smart-search@latest --no-save`
- verified CLI startup with `smart-search --version`
- verified `smart-search doctor --format json` starts successfully

## Notes
- `bun run fmt:check` and `bun run lint` could not run in this environment because `oxfmt` / `oxlint` were not available in PATH in the cloned repo environment
- this PR only changes `Dockerfile` and `README.md`
