### PR TITLE
fix: accept empty deferred subagent blocking reason

### DIFF
--- a/apps/core/src/tools/subagent.ts
+++ b/apps/core/src/tools/subagent.ts
@@ -30,7 +30,6 @@ const subagentDelegateInputSchema = z
       ),
     blockingReason: z
       .string()
-      .min(1)
       .optional()
       .describe(
         'Required when mode is "sync". Explain why the child result is immediately required before continuing.',

--- a/apps/core/tests/tools/subagent.test.ts
+++ b/apps/core/tests/tools/subagent.test.ts
@@ -168,6 +168,57 @@ describe("subagent_delegate tool", () => {
     ]);
   });
 
+  it("treats an empty deferred blockingReason as omitted", async () => {
+    const raw = createInMemoryRawBus();
+    const bus = createLilacBus(raw);
+
+    const launches: Array<{ childRequestId: string; childSessionId: string; task: string }> = [];
+
+    const tools = subagentTools({
+      bus,
+      defaultTimeoutMs: 2_000,
+      maxTimeoutMs: 4_000,
+      maxDepth: 1,
+      onDeferredDelegate: async (registration) => {
+        launches.push({
+          childRequestId: registration.childRequestId,
+          childSessionId: registration.childSessionId,
+          task: registration.task,
+        });
+      },
+    });
+
+    const res = await resolveExecuteResult(
+      tools.subagent_delegate.execute!(
+        {
+          profile: "explore",
+          task: "Map auth flow",
+          mode: "deferred",
+          blockingReason: "",
+        },
+        {
+          toolCallId: "tool-deferred-empty-blocking-reason",
+          messages: [],
+          context: {
+            requestId: "r:deferred-empty-blocking-reason",
+            sessionId: "s:deferred-empty-blocking-reason",
+            requestClient: "discord",
+            subagentDepth: 0,
+          },
+        },
+      ),
+    );
+
+    expect(res.status).toBe("accepted");
+    expect(launches).toEqual([
+      {
+        childRequestId: res.childRequestId,
+        childSessionId: res.childSessionId,
+        task: "Map auth flow",
+      },
+    ]);
+  });
+
   it("ignores legacy raw sessionId input and creates an anonymous child session", async () => {
     const raw = createInMemoryRawBus();
     const bus = createLilacBus(raw);
@@ -237,6 +288,22 @@ describe("subagent_delegate tool", () => {
           context: {
             requestId: "r:sync-validation",
             sessionId: "s:sync-validation",
+            requestClient: "discord",
+            subagentDepth: 0,
+          },
+        },
+      ),
+    ).rejects.toThrow(/blockingReason is required/i);
+
+    await expect(
+      tools.subagent_delegate.execute!(
+        { profile: "explore", task: "Map auth flow", mode: "sync", blockingReason: "" },
+        {
+          toolCallId: "tool-sync-empty-blocking-reason-validation",
+          messages: [],
+          context: {
+            requestId: "r:sync-empty-blocking-reason-validation",
+            sessionId: "s:sync-empty-blocking-reason-validation",
             requestClient: "discord",
             subagentDepth: 0,
           },


### PR DESCRIPTION
## Summary

This fixes the Catalina backend failure where `subagent_delegate` tool calls can be rejected before execution when the model sends:

```json
{
  "mode": "deferred",
  "blockingReason": ""
}
```

The source of the failure is that `blockingReason` was globally validated as `z.string().min(1).optional()`. That means an omitted value was allowed, but a present empty string was rejected for every mode. This conflicted with the tool contract and description, which only require `blockingReason` for `mode: "sync"`.

## Why this change is correct

`blockingReason` has different semantics depending on delegation mode:

- `deferred`: the parent does not need the child result immediately, so there is no blocking reason. An empty string from the model is equivalent to omission and should be tolerated.
- `sync`: the parent is explicitly blocking on the child result, so a non-empty `blockingReason` is still required.

The existing runtime path already normalizes blank values with:

```ts
const blockingReason = parsed.blockingReason?.trim() || undefined;
```

So the minimal correct fix is to remove the mode-agnostic `.min(1)` constraint from the schema and keep the sync-only validation in `superRefine` and the execute-time guard.

This keeps the intended safety rule intact for sync mode while preventing irrelevant deferred metadata from invalidating the entire tool call.

## Changes

- Allow `blockingReason` to be an optional string without a global non-empty constraint.
- Preserve the existing sync-only validation requiring a non-empty `blockingReason`.
- Add regression coverage for:
  - `mode: "deferred", blockingReason: ""` is accepted and treated as omitted.
  - `mode: "sync", blockingReason: ""` is still rejected.

## Validation

Ran:

```bash
cd apps/core && bun test tests/tools/subagent.test.ts
cd apps/core && bunx tsc -p tsconfig.json --noEmit
bun run lint:fix
bun run fmt
git diff --check
cd apps/core && bun test tests/tools/subagent.test.ts
```

Results:

- `tests/tools/subagent.test.ts`: 13 pass, 0 fail
- `apps/core` typecheck: pass
- `lint:fix`: 0 warnings, 0 errors
- `fmt`: completed
- `git diff --check`: pass