### PR TITLE
feat(generate): route image aliases through an OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,8 @@ CODEX_RESPONSES_TRANSPORT=
 # LILAC_LLM_WIRE_DEBUG_MAX_EVENTS=400
 
 # Provider: OpenAI-compatible
+# Used for text models and for generate.image when core-config.yaml sets
+# tools.generate.image.provider to openai-compatible.
 OPENAI_COMPATIBLE_BASE_URL=
 OPENAI_COMPATIBLE_API_KEY=
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -69,6 +69,7 @@ New v2 fields:
 - `agent.subagents.delegatePromptOverlay`: optional free-form guidance appended to the parent-visible `subagent_delegate` tool description.
 - `models.def.<alias>.comment`: optional guidance shown when an agent selects a model for a subagent.
 - `models.def.<alias>.agentCanSelect`: explicitly opts an alias into dynamic selection through `subagent_delegate`; defaults to `false`. It does not restrict static profiles, model slots, or explicit human overrides.
+- `tools.generate.image.provider`: transport routing switch for `generate.image`; values are `default` (built-in aliases) or `openai-compatible` (route through the OpenAI-compatible provider). Aliases and adapters remain unchanged; all aliases route together. Canonical model IDs are fixed. Selecting third-party routing has no automatic fallback. Frozen v1 configs receive the same `default` fallback but cannot opt in.
 
 Tool byte-size fields accept `B`, `KB`, `MB`, `GB`, `KiB`, `MiB`, and `GiB`. Duration fields accept `ms`, `s`, `m`, `h`, `d`, `w`, and `mo`; `mo` is a fixed 30 days. These fields cannot be configured in the frozen v1 input shape, but v1 receives the same universal runtime defaults.
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -396,6 +396,7 @@ Key sections:
 - `tools.web.extract.providers`: ordered web provider list shared by `web.search` and provider-backed `web.fetch`/extract (`tavily`, `exa`, `firecrawl`).
 - `tools.web.fetch.mode`: default fetch strategy (`auto`, `fetch`, `browser`, `extract`, or `provider-only`).
 - `agent.idleTimeoutMs`: primary agent inactivity timeout; active runs have no total runtime cap.
+- `tools.generate.image.provider`: transport routing switch (`default` | `openai-compatible`). When set to `openai-compatible`, image generation calls route through the OpenAI-compatible provider configured via `OPENAI_COMPATIBLE_BASE_URL` and `OPENAI_COMPATIBLE_API_KEY`. Aliases and adapters remain unchanged; all aliases route together. Canonical model IDs are fixed. Selecting third-party routing has no automatic fallback. See `docs/generate-image-openai-compatible.md` for setup and usage.
 - `agent.subagents`: subagent enablement/depth/timeout/profile config.
   - Built-in defaults: `explore` (read/search, no workspace writes/Bash/delegation), `general` (full useful tools/plugins, workspace writes, Bash, and network, without delegation), and `self` (the same plus delegation).
   - Each profile may configure Level-1 tools/plugins, Level-2 callables/plugins, network behavior, workspace-write behavior/tool exposure, execution, and delegation. `network` and `workspaceWrites` do not sandbox ordinary trusted Bash when execution is enabled. `resolveNativeSubagentProfile` is authoritative for every launch path, direct or workflow-launched.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ If you persist `/data`, the `smart-search` config and provider credentials persi
 - [`PROJECT.md`](./PROJECT.md): architecture, terminology, and runtime flow
 - [`AGENTS.md`](./AGENTS.md): repo-specific coding and validation rules
 - [`apps/acp-controller/README.md`](./apps/acp-controller/README.md): ACP controller usage details
+- [`docs/generate-image-openai-compatible.md`](./docs/generate-image-openai-compatible.md): routing `generate.image` through an OpenAI-compatible provider
 
 ### Runtime and deployment smoke commands
 

--- a/apps/core/src/plugins/builtin/server-tools.ts
+++ b/apps/core/src/plugins/builtin/server-tools.ts
@@ -104,7 +104,18 @@ export function createBuiltinCodexPlugin(): CoreToolPlugin {
 }
 
 export function createBuiltinGeneratePlugin(): CoreToolPlugin {
-  return singletonLevel2("generate", () => new Generate());
+  return {
+    meta: {
+      id: "generate",
+    },
+    create({ runtime }) {
+      const config = runtime.config;
+      const getConfig = runtime.getConfig ?? (config ? async () => config : undefined);
+      return {
+        level2: [new Generate({ getConfig })],
+      };
+    },
+  };
 }
 
 export function createBuiltinContentInspectPlugin(): CoreToolPlugin {

--- a/apps/core/src/plugins/builtin/server-tools.ts
+++ b/apps/core/src/plugins/builtin/server-tools.ts
@@ -1,4 +1,5 @@
 import { ToolPluginSkipError, type ServerTool } from "@stanley2058/lilac-plugin-runtime";
+import { getCoreConfig } from "@stanley2058/lilac-utils";
 
 import {
   Attachment,
@@ -110,7 +111,11 @@ export function createBuiltinGeneratePlugin(): CoreToolPlugin {
     },
     create({ runtime }) {
       const config = runtime.config;
-      const getConfig = runtime.getConfig ?? (config ? async () => config : undefined);
+      // Fall back to reading core-config from disk instead of leaving this
+      // undefined: an undefined getConfig makes Generate assume the "default"
+      // provider, which would silently route prompts to the built-in providers
+      // even when core-config.yaml selects "openai-compatible".
+      const getConfig = runtime.getConfig ?? (config ? async () => config : () => getCoreConfig());
       return {
         level2: [new Generate({ getConfig })],
       };

--- a/apps/core/src/tool-server/tools/generate.ts
+++ b/apps/core/src/tool-server/tools/generate.ts
@@ -1,4 +1,4 @@
-import { env, getModelProviders } from "@stanley2058/lilac-utils";
+import { env, getModelProviders, type CoreConfig } from "@stanley2058/lilac-utils";
 import {
   experimental_generateVideo as generateVideo,
   generateImage,
@@ -63,6 +63,10 @@ type SupportedImageModelId =
    *   9:19.5, 20:9, 9:20
    */
   | "grok-imagine-image-pro";
+
+type GenerateOptions = {
+  readonly getConfig?: () => Promise<Pick<CoreConfig, "tools">>;
+};
 
 type SupportedVideoModelId =
   /**
@@ -284,7 +288,13 @@ type ModelDescriptor<TId extends string, TModel, TInput> = {
   validateInput: (input: TInput) => void;
 };
 
-type ImageModelDescriptor = ModelDescriptor<SupportedImageModelId, ImageModel, ImageGenerateInput>;
+type ImageModelDescriptor = ModelDescriptor<
+  SupportedImageModelId,
+  ImageModel,
+  ImageGenerateInput
+> & {
+  readonly openAICompatibleModelId: string;
+};
 type VideoModelDescriptor = ModelDescriptor<
   SupportedVideoModelId,
   VideoModelObject,
@@ -430,6 +440,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "gpt-5-image",
+    openAICompatibleModelId: "gpt-image-1.5",
     createModel: (providers) => {
       if (isConfiguredProvider("openai")) {
         const model = providers.openai?.image("gpt-image-1.5");
@@ -446,6 +457,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "nanobanana",
+    openAICompatibleModelId: "google/gemini-2.5-flash-image",
     createModel: (providers) => {
       if (isConfiguredProvider("openrouter")) {
         return providers.openrouter?.imageModel("google/gemini-2.5-flash-image");
@@ -456,6 +468,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "nanobanana-2",
+    openAICompatibleModelId: "google/gemini-3.1-flash-image-preview",
     createModel: (providers) => {
       if (isConfiguredProvider("openrouter")) {
         return providers.openrouter?.imageModel("google/gemini-3.1-flash-image-preview");
@@ -476,6 +489,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "nanobanana-pro",
+    openAICompatibleModelId: "google/gemini-3-pro-image-preview",
     createModel: (providers) => {
       if (isConfiguredProvider("openrouter")) {
         return providers.openrouter?.imageModel("google/gemini-3-pro-image-preview");
@@ -486,6 +500,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "grok-imagine-image",
+    openAICompatibleModelId: "grok-imagine-image",
     createModel: (providers) => {
       if (!isConfiguredProvider("xai")) {
         return undefined;
@@ -496,6 +511,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "grok-imagine-image-pro",
+    openAICompatibleModelId: "grok-imagine-image-pro",
     createModel: (providers) => {
       if (!isConfiguredProvider("xai")) {
         return undefined;
@@ -571,8 +587,25 @@ function resolveAvailableModels<TId extends string, TModel, TInput>(
   };
 }
 
-function getAvailableImageModels() {
+function getAvailableImageModels(provider: "default" | "openai-compatible" = "default") {
   const providers = getModelProviders();
+  if (provider === "openai-compatible") {
+    const compatibleProvider = providers["openai-compatible"];
+    if (!env.providers.openaiCompatible.baseUrl?.trim() || !compatibleProvider) {
+      throw new Error(
+        "Image generation provider 'openai-compatible' requires OPENAI_COMPATIBLE_BASE_URL.",
+      );
+    }
+
+    return resolveAvailableModels(
+      IMAGE_MODEL_DESCRIPTORS.map((descriptor) => ({
+        ...descriptor,
+        createModel: () => compatibleProvider.imageModel(descriptor.openAICompatibleModelId),
+      })),
+      providers,
+    );
+  }
+
   return resolveAvailableModels(IMAGE_MODEL_DESCRIPTORS, providers);
 }
 
@@ -809,6 +842,7 @@ export function generateImageWithModel(
     abortSignal?: AbortSignal;
     size?: `${number}x${number}`;
     aspectRatio?: `${number}:${number}`;
+    maxRetries?: number;
   },
 ) {
   return generateImage({
@@ -817,6 +851,7 @@ export function generateImageWithModel(
     abortSignal: opts?.abortSignal,
     size: opts?.size,
     aspectRatio: opts?.aspectRatio,
+    maxRetries: opts?.maxRetries,
   });
 }
 
@@ -843,11 +878,19 @@ export function generateVideoWithModel(
 export class Generate implements ServerTool {
   id = "generate";
 
+  constructor(private readonly options: GenerateOptions = {}) {}
+
   async init(): Promise<void> {}
   async destroy(): Promise<void> {}
 
   async list() {
-    const imageModels = orderImageModelIds(getAvailableImageModels().ids);
+    const config = await this.options.getConfig?.();
+    const imageProvider = config?.tools.generate.image.provider ?? "default";
+    const imageModels = orderImageModelIds(
+      imageProvider === "openai-compatible"
+        ? IMAGE_MODEL_DESCRIPTORS.map((descriptor) => descriptor.id)
+        : getAvailableImageModels().ids,
+    );
     const videoModels = getAvailableVideoModels().ids;
     const tools = [];
 
@@ -913,8 +956,10 @@ export class Generate implements ServerTool {
       context?: RequestContext;
     },
   ): Promise<unknown> {
+    const config = await this.options.getConfig?.();
     const payload = imageGenerateInputSchema.parse(input);
-    const availableModels = getAvailableImageModels();
+    const imageProvider = config?.tools.generate.image.provider ?? "default";
+    const availableModels = getAvailableImageModels(imageProvider);
     const picked = pickModel(
       availableModels.available,
       payload.model,
@@ -942,6 +987,7 @@ export class Generate implements ServerTool {
       abortSignal: opts?.signal,
       size,
       aspectRatio,
+      maxRetries: imageProvider === "openai-compatible" ? 0 : undefined,
     });
 
     const image = res.image;

--- a/apps/core/src/tool-server/tools/generate.ts
+++ b/apps/core/src/tool-server/tools/generate.ts
@@ -424,6 +424,7 @@ function validateGrokImagineInput(
 const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   {
     id: "gpt-image-2",
+    openAICompatibleModelId: "gpt-image-2",
     createModel: (providers) => {
       if (isConfiguredProvider("openai")) {
         const model = providers.openai?.image("gpt-image-2");
@@ -479,6 +480,7 @@ const IMAGE_MODEL_DESCRIPTORS: readonly ImageModelDescriptor[] = [
   },
   {
     id: "nanobanana-2-lite",
+    openAICompatibleModelId: "google/gemini-3.1-flash-lite-image",
     createModel: (providers) => {
       if (isConfiguredProvider("openrouter")) {
         return providers.openrouter?.imageModel("google/gemini-3.1-flash-lite-image");

--- a/apps/core/tests/plugins/generate-registration.test.ts
+++ b/apps/core/tests/plugins/generate-registration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { LilacBus } from "@stanley2058/lilac-event-bus";
 import { env, parseCoreConfig } from "@stanley2058/lilac-utils";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +12,8 @@ import type { SurfaceAdapter } from "../../src/surface/adapter";
 
 const MISSING_BASE_URL_ERROR =
   "Image generation provider 'openai-compatible' requires OPENAI_COMPATIBLE_BASE_URL.";
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==";
 
 describe("generate plugin registration", () => {
   it("preserves video registration when compatible image base URL is missing", async () => {
@@ -64,6 +66,73 @@ describe("generate plugin registration", () => {
       server.stop(true);
       await rm(dataDir, { force: true, recursive: true });
       Object.assign(env.providers.xai, originalXai);
+      Object.assign(env.providers.openaiCompatible, originalCompatible);
+    }
+  });
+
+  it("honors the on-disk provider when the runtime supplies neither config nor getConfig", async () => {
+    // Given
+    const originalOpenai = { ...env.providers.openai };
+    const originalCompatible = { ...env.providers.openaiCompatible };
+    let compatibleRequests = 0;
+    let officialRequests = 0;
+    const compatibleServer = Bun.serve({
+      port: 0,
+      fetch: () => {
+        compatibleRequests += 1;
+        return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+      },
+    });
+    const officialServer = Bun.serve({
+      port: 0,
+      fetch: () => {
+        officialRequests += 1;
+        return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+      },
+    });
+    Object.assign(env.providers.openaiCompatible, {
+      apiKey: "compatible-key",
+      baseUrl: `http://127.0.0.1:${compatibleServer.port}/v1`,
+    });
+    Object.assign(env.providers.openai, {
+      apiKey: "official-key",
+      baseUrl: `http://127.0.0.1:${officialServer.port}/v1`,
+    });
+    await writeFile(
+      join(env.dataDir, "core-config.yaml"),
+      "configVersion: 2\ntools:\n  generate:\n    image:\n      provider: openai-compatible\n",
+    );
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-generate-ondisk-"));
+    const manager = createCoreToolPluginManager({
+      runtime: {
+        bus: {} as LilacBus,
+        adapter: {} as SurfaceAdapter,
+        discovery: {} as DiscoveryService,
+        conversationThreads: {} as ConversationThreadService,
+      },
+      dataDir: env.dataDir,
+    });
+
+    try {
+      // When
+      await manager.init();
+      const generate = manager.getLevel2Tools().find((tool) => tool.id === "generate");
+      await generate?.call("generate.image", {
+        prompt: "must reach the compatible endpoint",
+        model: "gpt-image-2",
+        outputDir,
+      });
+
+      // Then
+      expect(compatibleRequests).toBe(1);
+      expect(officialRequests).toBe(0);
+    } finally {
+      await manager.destroy();
+      compatibleServer.stop(true);
+      officialServer.stop(true);
+      await rm(join(env.dataDir, "core-config.yaml"), { force: true });
+      await rm(outputDir, { force: true, recursive: true });
+      Object.assign(env.providers.openai, originalOpenai);
       Object.assign(env.providers.openaiCompatible, originalCompatible);
     }
   });

--- a/apps/core/tests/plugins/generate-registration.test.ts
+++ b/apps/core/tests/plugins/generate-registration.test.ts
@@ -72,6 +72,7 @@ describe("generate plugin registration", () => {
 
   it("honors the on-disk provider when the runtime supplies neither config nor getConfig", async () => {
     // Given
+    const originalDataDir = env.dataDir;
     const originalOpenai = { ...env.providers.openai };
     const originalCompatible = { ...env.providers.openaiCompatible };
     let compatibleRequests = 0;
@@ -98,8 +99,10 @@ describe("generate plugin registration", () => {
       apiKey: "official-key",
       baseUrl: `http://127.0.0.1:${officialServer.port}/v1`,
     });
+    const dataDir = await mkdtemp(join(tmpdir(), "lilac-generate-data-"));
+    Object.assign(env, { dataDir });
     await writeFile(
-      join(env.dataDir, "core-config.yaml"),
+      join(dataDir, "core-config.yaml"),
       "configVersion: 2\ntools:\n  generate:\n    image:\n      provider: openai-compatible\n",
     );
     const outputDir = await mkdtemp(join(tmpdir(), "lilac-generate-ondisk-"));
@@ -110,7 +113,7 @@ describe("generate plugin registration", () => {
         discovery: {} as DiscoveryService,
         conversationThreads: {} as ConversationThreadService,
       },
-      dataDir: env.dataDir,
+      dataDir,
     });
 
     try {
@@ -130,7 +133,8 @@ describe("generate plugin registration", () => {
       await manager.destroy();
       compatibleServer.stop(true);
       officialServer.stop(true);
-      await rm(join(env.dataDir, "core-config.yaml"), { force: true });
+      Object.assign(env, { dataDir: originalDataDir });
+      await rm(dataDir, { force: true, recursive: true });
       await rm(outputDir, { force: true, recursive: true });
       Object.assign(env.providers.openai, originalOpenai);
       Object.assign(env.providers.openaiCompatible, originalCompatible);

--- a/apps/core/tests/plugins/generate-registration.test.ts
+++ b/apps/core/tests/plugins/generate-registration.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import type { LilacBus } from "@stanley2058/lilac-event-bus";
+import { env, parseCoreConfig } from "@stanley2058/lilac-utils";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ConversationThreadService } from "../../src/conversation/thread-service";
+import type { DiscoveryService } from "../../src/discovery/discovery-service";
+import { createCoreToolPluginManager } from "../../src/plugins";
+import type { SurfaceAdapter } from "../../src/surface/adapter";
+
+const MISSING_BASE_URL_ERROR =
+  "Image generation provider 'openai-compatible' requires OPENAI_COMPATIBLE_BASE_URL.";
+
+describe("generate plugin registration", () => {
+  it("preserves video registration when compatible image base URL is missing", async () => {
+    // Given
+    const originalXai = { ...env.providers.xai };
+    const originalCompatible = { ...env.providers.openaiCompatible };
+    let requestCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => {
+        requestCount += 1;
+        return Response.json({});
+      },
+    });
+    const dataDir = await mkdtemp(join(tmpdir(), "lilac-generate-registration-"));
+    Object.assign(env.providers.xai, {
+      apiKey: "video-key",
+      baseUrl: `http://127.0.0.1:${server.port}/v1`,
+    });
+    Object.assign(env.providers.openaiCompatible, { apiKey: undefined, baseUrl: undefined });
+    const config = await parseCoreConfig({
+      configVersion: 2,
+      tools: { generate: { image: { provider: "openai-compatible" } } },
+    });
+    const manager = createCoreToolPluginManager({
+      runtime: {
+        bus: {} as LilacBus,
+        adapter: {} as SurfaceAdapter,
+        discovery: {} as DiscoveryService,
+        conversationThreads: {} as ConversationThreadService,
+        config,
+      },
+      dataDir,
+    });
+
+    try {
+      // When
+      await manager.init();
+      const generate = manager.getLevel2Tools().find((tool) => tool.id === "generate");
+      const entries = await generate?.list();
+
+      // Then
+      expect(entries?.map((entry) => entry.callableId)).toContain("generate.video");
+      await expect(
+        generate?.call("generate.image", { prompt: "must fail before HTTP" }),
+      ).rejects.toThrow(MISSING_BASE_URL_ERROR);
+      expect(requestCount).toBe(0);
+    } finally {
+      await manager.destroy();
+      server.stop(true);
+      await rm(dataDir, { force: true, recursive: true });
+      Object.assign(env.providers.xai, originalXai);
+      Object.assign(env.providers.openaiCompatible, originalCompatible);
+    }
+  });
+});

--- a/apps/core/tests/tool-server/generate-construction.test.ts
+++ b/apps/core/tests/tool-server/generate-construction.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { parseCoreConfig } from "@stanley2058/lilac-utils";
+
+import { createBuiltinGeneratePlugin } from "../../src/plugins/builtin/server-tools";
+import { Generate } from "../../src/tool-server/tools/generate";
+
+describe("Generate construction", () => {
+  it("preserves direct construction and list behavior", async () => {
+    // Given
+    const generate = new Generate();
+
+    // When
+    const entries = await generate.list();
+
+    // Then
+    expect(generate.id).toBe("generate");
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.every((entry) => entry.callableId.startsWith("generate."))).toBe(true);
+  });
+
+  it("preserves built-in plugin construction and list behavior", async () => {
+    // Given
+    const plugin = createBuiltinGeneratePlugin();
+
+    // When
+    const created = await plugin.create({
+      runtime: {},
+      dataDir: "/tmp",
+      pluginConfig: undefined,
+      source: "builtin",
+    });
+    const generate = created.level2?.[0];
+
+    // Then
+    expect(plugin.meta.id).toBe("generate");
+    expect(generate).toBeInstanceOf(Generate);
+    expect(await generate?.list()).toEqual(await new Generate().list());
+  });
+
+  it("reads the built-in plugin config lazily through Generate", async () => {
+    // Given
+    const config = await parseCoreConfig({ configVersion: 2 });
+    let observedProvider: string | undefined;
+    const plugin = createBuiltinGeneratePlugin();
+    const created = await plugin.create({
+      runtime: {
+        getConfig: async () => {
+          observedProvider = config.tools.generate.image.provider;
+          return config;
+        },
+      },
+      dataDir: "/tmp",
+      pluginConfig: undefined,
+      source: "builtin",
+    });
+    const generate = created.level2?.[0];
+    expect(observedProvider).toBeUndefined();
+
+    // When
+    await generate?.list();
+
+    // Then
+    expect(observedProvider).toBe("default");
+  });
+
+  it("propagates a rejected built-in plugin config getter from Generate", async () => {
+    // Given
+    const configError = new Error("invalid core config");
+    const plugin = createBuiltinGeneratePlugin();
+    const created = await plugin.create({
+      runtime: {
+        getConfig: async () => {
+          throw configError;
+        },
+      },
+      dataDir: "/tmp",
+      pluginConfig: undefined,
+      source: "builtin",
+    });
+    const generate = created.level2?.[0];
+
+    // When / Then
+    await expect(generate?.list()).rejects.toBe(configError);
+  });
+});

--- a/apps/core/tests/tool-server/generate-image-characterization.test.ts
+++ b/apps/core/tests/tool-server/generate-image-characterization.test.ts
@@ -61,7 +61,7 @@ describe("Generate image upstream characterization", () => {
 
     // Then
     expect(entries.find((entry) => entry.callableId === "generate.image")?.description).toEndWith(
-      "Available models: gpt-5-image, nanobanana, nanobanana-2, nanobanana-pro, grok-imagine-image, grok-imagine-image-pro",
+      "Available models: gpt-image-2, nanobanana-2, nanobanana-pro, gpt-5-image, grok-imagine-image-pro, grok-imagine-image, nanobanana-2-lite, nanobanana",
     );
   });
 
@@ -111,10 +111,20 @@ describe("Generate image upstream characterization", () => {
     temporaryPaths.push(outputDir);
 
     // When / Then
+    // With only OpenRouter configured, the fallback order still resolves to
+    // gpt-image-2, so its validator rejects a ratio it does not support.
     await expect(
       new Generate().call("generate.image", {
         prompt: "test",
         aspectRatio: "1:8",
+        inputImages: [join(outputDir, "missing.png")],
+      }),
+    ).rejects.toThrow("Unsupported aspectRatio '1:8' for gpt-image-2");
+    // A supported ratio gets past validation and fails on the missing input.
+    await expect(
+      new Generate().call("generate.image", {
+        prompt: "test",
+        aspectRatio: "1:1",
         inputImages: [join(outputDir, "missing.png")],
       }),
     ).rejects.toMatchObject({ code: "ENOENT" });

--- a/apps/core/tests/tool-server/generate-image-characterization.test.ts
+++ b/apps/core/tests/tool-server/generate-image-characterization.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { env } from "@stanley2058/lilac-utils";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildImageGenerationPrompt, Generate } from "../../src/tool-server/tools/generate";
+
+const PNG_BYTES = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0xf0,
+  0x1f, 0x00, 0x05, 0x00, 0x01, 0xff, 0x89, 0x99, 0x3d, 0x1d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+  0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+const originalProviders = structuredClone(env.providers);
+const temporaryPaths: string[] = [];
+const servers: Bun.Server<unknown>[] = [];
+
+function configureProviders(values: {
+  readonly openai?: string;
+  readonly openrouter?: string;
+  readonly xai?: string;
+}): void {
+  Object.assign(env.providers.openai, {
+    apiKey: values.openai ? "test-key" : undefined,
+    baseUrl: values.openai,
+  });
+  Object.assign(env.providers.openrouter, {
+    apiKey: values.openrouter ? "test-key" : undefined,
+    baseUrl: values.openrouter,
+  });
+  Object.assign(env.providers.xai, {
+    apiKey: values.xai ? "test-key" : undefined,
+    baseUrl: values.xai,
+  });
+  Object.assign(env.providers.openaiCompatible, { apiKey: undefined, baseUrl: undefined });
+}
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) server.stop(true);
+  for (const path of temporaryPaths.splice(0)) await rm(path, { force: true, recursive: true });
+  Object.assign(env.providers.openai, originalProviders.openai);
+  Object.assign(env.providers.openrouter, originalProviders.openrouter);
+  Object.assign(env.providers.xai, originalProviders.xai);
+  Object.assign(env.providers.openaiCompatible, originalProviders.openaiCompatible);
+});
+
+describe("Generate image upstream characterization", () => {
+  it("preserves the image alias list and descriptor order", async () => {
+    // Given
+    configureProviders({
+      openai: "http://127.0.0.1",
+      openrouter: "http://127.0.0.1",
+      xai: "http://127.0.0.1",
+    });
+
+    // When
+    const entries = await new Generate().list();
+
+    // Then
+    expect(entries.find((entry) => entry.callableId === "generate.image")?.description).toEndWith(
+      "Available models: gpt-5-image, nanobanana, nanobanana-2, nanobanana-pro, grok-imagine-image, grok-imagine-image-pro",
+    );
+  });
+
+  it("preserves model-specific validators before any HTTP request", async () => {
+    // Given
+    let requestCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => {
+        requestCount += 1;
+        return Response.json({ data: [] });
+      },
+    });
+    servers.push(server);
+    const baseUrl = `http://127.0.0.1:${server.port}/v1`;
+    configureProviders({ openai: baseUrl, openrouter: baseUrl, xai: baseUrl });
+    const generate = new Generate();
+
+    // When / Then
+    await expect(
+      generate.call("generate.image", { prompt: "test", model: "gpt-5-image", size: "512x512" }),
+    ).rejects.toThrow("Unsupported size '512x512' for gpt-5-image");
+    await expect(
+      generate.call("generate.image", { prompt: "test", model: "nanobanana", aspectRatio: "1:8" }),
+    ).rejects.toThrow("Unsupported aspectRatio '1:8' for nanobanana");
+    await expect(
+      generate.call("generate.image", {
+        prompt: "test",
+        model: "grok-imagine-image",
+        size: "1024x1024",
+      }),
+    ).rejects.toThrow("grok-imagine-image does not support size");
+    await expect(
+      generate.call("generate.image", {
+        prompt: "test",
+        model: "grok-imagine-image-pro",
+        inputImages: ["first.png", "second.png"],
+      }),
+    ).rejects.toThrow("grok-imagine-image-pro supports only one input image");
+    expect(requestCount).toBe(0);
+  });
+
+  it("preserves default provider fallback selection", async () => {
+    // Given
+    configureProviders({ openrouter: "http://127.0.0.1" });
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-generate-fallback-"));
+    temporaryPaths.push(outputDir);
+
+    // When / Then
+    await expect(
+      new Generate().call("generate.image", {
+        prompt: "test",
+        aspectRatio: "1:8",
+        inputImages: [join(outputDir, "missing.png")],
+      }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves generation result fields and unique PNG filename behavior", async () => {
+    // Given
+    const server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        Response.json({ data: [{ b64_json: Buffer.from(PNG_BYTES).toString("base64") }] }),
+    });
+    servers.push(server);
+    configureProviders({ openai: `http://127.0.0.1:${server.port}/v1` });
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-generate-result-"));
+    temporaryPaths.push(outputDir);
+    await writeFile(join(outputDir, "generated-image.png"), PNG_BYTES);
+
+    // When
+    const result = await new Generate().call("generate.image", {
+      prompt: "a violet square",
+      model: "gpt-5-image",
+      outputDir,
+    });
+
+    // Then
+    expect(result).toEqual({
+      ok: true,
+      path: join(outputDir, "generated-image (1).png"),
+      bytes: PNG_BYTES.byteLength,
+      mimeType: "image/png",
+      model: "gpt-5-image",
+      warnings: [],
+    });
+    expect(await readFile(join(outputDir, "generated-image (1).png"))).toEqual(
+      Buffer.from(PNG_BYTES),
+    );
+  });
+
+  it("preserves edit prompt image and mask conversion", async () => {
+    // Given
+    const directory = await mkdtemp(join(tmpdir(), "lilac-generate-edit-"));
+    temporaryPaths.push(directory);
+    await writeFile(join(directory, "source.png"), PNG_BYTES);
+    await writeFile(join(directory, "mask.png"), PNG_BYTES);
+
+    // When
+    const prompt = await buildImageGenerationPrompt(directory, {
+      prompt: "replace the background",
+      inputImages: ["source.png"],
+      maskImage: "mask.png",
+    });
+
+    // Then
+    expect(prompt).toEqual({
+      text: "replace the background",
+      images: [Buffer.from(PNG_BYTES)],
+      mask: Buffer.from(PNG_BYTES),
+    });
+  });
+});

--- a/apps/core/tests/tool-server/generate-image-openai-compatible.test.ts
+++ b/apps/core/tests/tool-server/generate-image-openai-compatible.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { env, parseCoreConfig, type CoreConfig } from "@stanley2058/lilac-utils";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Generate } from "../../src/tool-server/tools/generate";
+
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==";
+const PNG_BYTES = Buffer.from(PNG_BASE64, "base64");
+const CONFIG_ERROR =
+  "Image generation provider 'openai-compatible' requires OPENAI_COMPATIBLE_BASE_URL.";
+const ALIAS_CASES = [
+  ["gpt-5-image", "gpt-image-1.5"],
+  ["nanobanana", "google/gemini-2.5-flash-image"],
+  ["nanobanana-2", "google/gemini-3.1-flash-image-preview"],
+  ["nanobanana-pro", "google/gemini-3-pro-image-preview"],
+  ["grok-imagine-image", "grok-imagine-image"],
+  ["grok-imagine-image-pro", "grok-imagine-image-pro"],
+] as const;
+
+const originalProviders = structuredClone(env.providers);
+const temporaryPaths: string[] = [];
+const servers: Bun.Server<unknown>[] = [];
+
+async function compatibleConfig(): Promise<Pick<CoreConfig, "tools">> {
+  const config = await parseCoreConfig({
+    configVersion: 2,
+    tools: { generate: { image: { provider: "openai-compatible" } } },
+  });
+  return config;
+}
+
+function configureCompatible(baseUrl: string | undefined): void {
+  Object.assign(env.providers.openaiCompatible, {
+    apiKey: baseUrl ? "compatible-key" : undefined,
+    baseUrl,
+  });
+}
+
+function startServer(
+  fetch: (request: Request) => Response | Promise<Response>,
+): Bun.Server<unknown> {
+  const server = Bun.serve({ port: 0, fetch });
+  servers.push(server);
+  return server;
+}
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) server.stop(true);
+  for (const path of temporaryPaths.splice(0)) await rm(path, { force: true, recursive: true });
+  Object.assign(env.providers.openai, originalProviders.openai);
+  Object.assign(env.providers.openrouter, originalProviders.openrouter);
+  Object.assign(env.providers.xai, originalProviders.xai);
+  Object.assign(env.providers.openaiCompatible, originalProviders.openaiCompatible);
+});
+
+describe("Generate OpenAI-compatible image routing", () => {
+  it.each(ALIAS_CASES)("routes %s to canonical model %s", async (alias, canonicalId) => {
+    // Given
+    let body: unknown;
+    const server = startServer(async (request) => {
+      body = await request.json();
+      return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-compatible-alias-"));
+    temporaryPaths.push(outputDir);
+
+    // When
+    const result = await new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+      prompt: "canonical route",
+      model: alias,
+      outputDir,
+    });
+
+    // Then
+    expect(body).toMatchObject({ model: canonicalId });
+    expect(result).toMatchObject({ ok: true, model: alias, mimeType: "image/png" });
+  });
+
+  it("throws a stable configuration error before default fallback", async () => {
+    // Given
+    configureCompatible(undefined);
+    Object.assign(env.providers.openai, { apiKey: "official-key", baseUrl: "http://127.0.0.1" });
+
+    // When / Then
+    await expect(
+      new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+        prompt: "no request",
+      }),
+    ).rejects.toThrow(CONFIG_ERROR);
+  });
+
+  it("rejects invalid compatible input before HTTP", async () => {
+    // Given
+    let requestCount = 0;
+    const server = startServer(() => {
+      requestCount += 1;
+      return Response.json({ data: [] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const generate = new Generate({ getConfig: compatibleConfig });
+
+    // When / Then
+    await expect(
+      generate.call("generate.image", {
+        prompt: "invalid",
+        model: "gpt-5-image",
+        size: "512x512",
+      }),
+    ).rejects.toThrow("Unsupported size '512x512' for gpt-5-image");
+    await expect(
+      generate.call("generate.image", {
+        prompt: "invalid",
+        model: "grok-imagine-image",
+        maskImage: "mask.png",
+        inputImages: "source.png",
+      }),
+    ).rejects.toThrow("grok-imagine-image does not support maskImage");
+    expect(requestCount).toBe(0);
+  });
+
+  it("uses the JSON generation path and preserves output PNG", async () => {
+    // Given
+    let capture:
+      | { method: string; path: string; authorization: string | null; body: unknown }
+      | undefined;
+    const server = startServer(async (request) => {
+      capture = {
+        method: request.method,
+        path: new URL(request.url).pathname,
+        authorization: request.headers.get("authorization"),
+        body: await request.json(),
+      };
+      return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-compatible-json-"));
+    temporaryPaths.push(outputDir);
+
+    // When
+    const result = await new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+      prompt: "json prompt",
+      model: "gpt-5-image",
+      size: "1024x1024",
+      outputDir,
+    });
+
+    // Then
+    expect(capture).toEqual({
+      method: "POST",
+      path: "/v1/images/generations",
+      authorization: "Bearer compatible-key",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "json prompt",
+        n: 1,
+        size: "1024x1024",
+        response_format: "b64_json",
+      },
+    });
+    expect(await readFile(join(outputDir, "generated-image.png"))).toEqual(PNG_BYTES);
+    expect(result).toMatchObject({ path: join(outputDir, "generated-image.png") });
+  });
+
+  it("uses the multipart edit path", async () => {
+    // Given
+    let capture: { method: string; path: string; fields: Record<string, string> } | undefined;
+    const server = startServer(async (request) => {
+      const fields: Record<string, string> = {};
+      for (const [key, value] of await request.formData()) {
+        fields[key] = typeof value === "string" ? value : `${value.type}:${value.size}`;
+      }
+      capture = { method: request.method, path: new URL(request.url).pathname, fields };
+      return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-compatible-edit-"));
+    temporaryPaths.push(outputDir);
+    await writeFile(join(outputDir, "source.png"), PNG_BYTES);
+    await writeFile(join(outputDir, "mask.png"), PNG_BYTES);
+
+    // When
+    await new Generate({ getConfig: compatibleConfig }).call(
+      "generate.image",
+      {
+        prompt: "edit prompt",
+        model: "gpt-5-image",
+        inputImages: "source.png",
+        maskImage: "mask.png",
+        outputDir,
+      },
+      { context: { cwd: outputDir } },
+    );
+
+    // Then
+    expect(capture).toEqual({
+      method: "POST",
+      path: "/v1/images/edits",
+      fields: {
+        image: "image/png:70",
+        mask: "image/png:70",
+        model: "gpt-image-1.5",
+        n: "1",
+        prompt: "edit prompt",
+      },
+    });
+  });
+
+  it("propagates HTTP 500 after exactly one request without official fallback", async () => {
+    // Given
+    let requestCount = 0;
+    const server = startServer(() => {
+      requestCount += 1;
+      return Response.json(
+        { error: { message: "compatible failed", type: "server_error" } },
+        { status: 500 },
+      );
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    Object.assign(env.providers.openai, {
+      apiKey: "official-key",
+      baseUrl: "http://127.0.0.1:1/v1",
+    });
+
+    // When / Then
+    await expect(
+      new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+        prompt: "fail once",
+        model: "gpt-5-image",
+      }),
+    ).rejects.toThrow("compatible failed");
+    expect(requestCount).toBe(1);
+  });
+
+  it("rejects a malformed success response after one request without output", async () => {
+    // Given
+    let requestCount = 0;
+    const server = startServer(() => {
+      requestCount += 1;
+      return Response.json({ data: [{}] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-compatible-malformed-"));
+    temporaryPaths.push(outputDir);
+
+    // When / Then
+    await expect(
+      new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+        prompt: "malformed once",
+        model: "gpt-5-image",
+        outputDir,
+      }),
+    ).rejects.toThrow();
+    expect(requestCount).toBe(1);
+    expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: outputDir }))).toEqual([]);
+  });
+});

--- a/apps/core/tests/tool-server/generate-image-openai-compatible.test.ts
+++ b/apps/core/tests/tool-server/generate-image-openai-compatible.test.ts
@@ -257,4 +257,72 @@ describe("Generate OpenAI-compatible image routing", () => {
     expect(requestCount).toBe(1);
     expect(await Array.fromAsync(new Bun.Glob("*").scan({ cwd: outputDir }))).toEqual([]);
   });
+
+  it("drops aspectRatio upstream and surfaces an unsupported warning", async () => {
+    // Given
+    const previousLogWarnings = globalThis.AI_SDK_LOG_WARNINGS;
+    globalThis.AI_SDK_LOG_WARNINGS = false;
+    let body: unknown;
+    const server = startServer(async (request) => {
+      body = await request.json();
+      return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-compatible-aspect-"));
+    temporaryPaths.push(outputDir);
+
+    // When
+    try {
+      const result = await new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+        prompt: "wide shot",
+        model: "nanobanana-2",
+        aspectRatio: "16:9",
+        outputDir,
+      });
+
+      // Then
+      expect(body).toEqual({
+        model: "google/gemini-3.1-flash-image-preview",
+        prompt: "wide shot",
+        n: 1,
+        response_format: "b64_json",
+      });
+      expect(result).toMatchObject({
+        ok: true,
+        warnings: [{ type: "unsupported", feature: "aspectRatio" }],
+      });
+    } finally {
+      globalThis.AI_SDK_LOG_WARNINGS = previousLogWarnings;
+    }
+  });
+
+  it("still converts aspectRatio to size for gpt aliases", async () => {
+    // Given
+    let body: unknown;
+    const server = startServer(async (request) => {
+      body = await request.json();
+      return Response.json({ data: [{ b64_json: PNG_BASE64 }] });
+    });
+    configureCompatible(`http://127.0.0.1:${server.port}/v1`);
+    const outputDir = await mkdtemp(join(tmpdir(), "lilac-compatible-gpt-aspect-"));
+    temporaryPaths.push(outputDir);
+
+    // When
+    const result = await new Generate({ getConfig: compatibleConfig }).call("generate.image", {
+      prompt: "portrait shot",
+      model: "gpt-5-image",
+      aspectRatio: "2:3",
+      outputDir,
+    });
+
+    // Then
+    expect(body).toEqual({
+      model: "gpt-image-1.5",
+      prompt: "portrait shot",
+      n: 1,
+      size: "1024x1536",
+      response_format: "b64_json",
+    });
+    expect(result).toMatchObject({ ok: true, warnings: [] });
+  });
 });

--- a/apps/core/tests/tool-server/generate-image-openai-compatible.test.ts
+++ b/apps/core/tests/tool-server/generate-image-openai-compatible.test.ts
@@ -12,9 +12,11 @@ const PNG_BYTES = Buffer.from(PNG_BASE64, "base64");
 const CONFIG_ERROR =
   "Image generation provider 'openai-compatible' requires OPENAI_COMPATIBLE_BASE_URL.";
 const ALIAS_CASES = [
+  ["gpt-image-2", "gpt-image-2"],
   ["gpt-5-image", "gpt-image-1.5"],
   ["nanobanana", "google/gemini-2.5-flash-image"],
   ["nanobanana-2", "google/gemini-3.1-flash-image-preview"],
+  ["nanobanana-2-lite", "google/gemini-3.1-flash-lite-image"],
   ["nanobanana-pro", "google/gemini-3-pro-image-preview"],
   ["grok-imagine-image", "grok-imagine-image"],
   ["grok-imagine-image-pro", "grok-imagine-image-pro"],

--- a/apps/tool-bridge/create-plugin-manager.test.ts
+++ b/apps/tool-bridge/create-plugin-manager.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { parseCoreConfig } from "@stanley2058/lilac-utils";
+
+import { createToolBridgePluginManager } from "./create-plugin-manager";
+
+describe("tool-bridge plugin manager construction", () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true });
+    tmpRoot = undefined;
+  });
+
+  it("preserves standalone bridge Generate construction and list behavior", async () => {
+    // Given
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "lilac-tool-bridge-"));
+    const manager = createToolBridgePluginManager({
+      dataDir: path.join(tmpRoot, "data"),
+    });
+
+    // When
+    await manager.init();
+    const generate = manager.getLevel2Tools().find((tool) => tool.id === "generate");
+
+    // Then
+    expect(generate).toBeDefined();
+    expect(Array.isArray(await generate?.list())).toBe(true);
+
+    await manager.destroy();
+  });
+
+  it("reads the standalone bridge config lazily through Generate", async () => {
+    // Given
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "lilac-tool-bridge-"));
+    const config = await parseCoreConfig({
+      configVersion: 2,
+      tools: {
+        generate: {
+          image: {
+            provider: "default",
+          },
+        },
+      },
+    });
+    const observedProviders: string[] = [];
+    const manager = createToolBridgePluginManager({
+      dataDir: path.join(tmpRoot, "data"),
+      getConfig: async () => {
+        observedProviders.push(config.tools.generate.image.provider);
+        return config;
+      },
+    });
+    await manager.init();
+    const generate = manager.getLevel2Tools().find((tool) => tool.id === "generate");
+    const observationsAfterInit = observedProviders.length;
+
+    // When
+    await generate?.list();
+
+    // Then
+    expect(observedProviders.length).toBeGreaterThan(observationsAfterInit);
+    expect(observedProviders.at(-1)).toBe("default");
+
+    await manager.destroy();
+  });
+
+  it("propagates a rejected standalone bridge config getter from Generate", async () => {
+    // Given
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "lilac-tool-bridge-"));
+    const config = await parseCoreConfig({ configVersion: 2 });
+    const configError = new Error("invalid bridge config");
+    let rejected = false;
+    const manager = createToolBridgePluginManager({
+      dataDir: path.join(tmpRoot, "data"),
+      getConfig: async () => {
+        if (rejected) throw configError;
+        return config;
+      },
+    });
+    await manager.init();
+    const generate = manager.getLevel2Tools().find((tool) => tool.id === "generate");
+    rejected = true;
+
+    // When / Then
+    await expect(generate?.list()).rejects.toBe(configError);
+
+    await manager.destroy();
+  });
+});

--- a/apps/tool-bridge/create-plugin-manager.ts
+++ b/apps/tool-bridge/create-plugin-manager.ts
@@ -1,0 +1,14 @@
+import { createCoreToolPluginManager } from "@stanley2058/lilac-core";
+import { getCoreConfig, type CoreConfig } from "@stanley2058/lilac-utils";
+
+export function createToolBridgePluginManager(params: {
+  readonly dataDir: string;
+  readonly getConfig?: () => Promise<CoreConfig>;
+}) {
+  return createCoreToolPluginManager({
+    runtime: {
+      getConfig: params.getConfig ?? (() => getCoreConfig()),
+    },
+    dataDir: params.dataDir,
+  });
+}

--- a/apps/tool-bridge/index.ts
+++ b/apps/tool-bridge/index.ts
@@ -1,16 +1,13 @@
 import { createLogger, env } from "@stanley2058/lilac-utils";
-import {
-  createCoreToolPluginManager,
-  createProcessHandlers,
-  createToolServer,
-} from "@stanley2058/lilac-core";
+import { createProcessHandlers, createToolServer } from "@stanley2058/lilac-core";
+
+import { createToolBridgePluginManager } from "./create-plugin-manager";
 
 const logger = createLogger({
   module: "tool-bridge",
 });
 
-const pluginManager = createCoreToolPluginManager({
-  runtime: {},
+const pluginManager = createToolBridgePluginManager({
   dataDir: env.dataDir,
 });
 

--- a/docs/generate-image-openai-compatible.md
+++ b/docs/generate-image-openai-compatible.md
@@ -59,9 +59,11 @@ Lilac sends the corresponding canonical model ID to the provider.
 
 | Lilac alias | Canonical model ID sent upstream |
 | --- | --- |
+| `gpt-image-2` | `gpt-image-2` |
 | `gpt-5-image` | `gpt-image-1.5` |
 | `nanobanana` | `google/gemini-2.5-flash-image` |
 | `nanobanana-2` | `google/gemini-3.1-flash-image-preview` |
+| `nanobanana-2-lite` | `google/gemini-3.1-flash-lite-image` |
 | `nanobanana-pro` | `google/gemini-3-pro-image-preview` |
 | `grok-imagine-image` | `grok-imagine-image` |
 | `grok-imagine-image-pro` | `grok-imagine-image-pro` |

--- a/docs/generate-image-openai-compatible.md
+++ b/docs/generate-image-openai-compatible.md
@@ -159,6 +159,37 @@ existing OpenAI, OpenRouter, and xAI provider selection behavior.
   OpenAI-compatible routing is selected.
 - `generate.video` remains independent of this image-provider setting.
 
+## Known limitation: `aspectRatio` is not sent upstream
+
+The OpenAI-compatible image API has no aspect-ratio parameter, so
+`aspectRatio` is **not** forwarded to the provider in this mode. Lilac still
+validates it against the alias, then the request omits it and the result
+carries a warning:
+
+```json
+{
+  "type": "unsupported",
+  "feature": "aspectRatio",
+  "details": "This model does not support aspect ratio. Use `size` instead."
+}
+```
+
+The image is generated at the provider's default ratio. This differs from
+`default` mode, where `aspectRatio` reaches OpenRouter and xAI as a real
+parameter.
+
+Practical consequences:
+
+- Prefer `size` in this mode. For `gpt-image-2` and `gpt-5-image`, Lilac
+  already converts `aspectRatio` into an equivalent `size`, so those two
+  aliases are unaffected.
+- The `nanobanana*` and `grok-imagine-image*` aliases are aspect-ratio-driven
+  and have no `size` equivalent here. `grok-imagine-image*` rejects `size`
+  outright, so in this mode those aliases can only produce the provider's
+  default ratio.
+- Check the `warnings` array in the tool result to detect a dropped
+  `aspectRatio`.
+
 ## Troubleshooting
 
 ### The provider returns model-not-found

--- a/docs/generate-image-openai-compatible.md
+++ b/docs/generate-image-openai-compatible.md
@@ -1,0 +1,188 @@
+# OpenAI-Compatible Image Generation
+
+Lilac can route the existing `generate.image` model aliases through one
+OpenAI-compatible provider. This changes the request destination only. Existing
+aliases, input validation, image editing behavior, and output handling remain
+unchanged.
+
+## Requirements
+
+The provider must implement the OpenAI-compatible image endpoints:
+
+- `POST /images/generations` for image generation
+- `POST /images/edits` for image editing and masks
+
+The configured base URL is prepended to those paths. For example, a base URL of
+`https://provider.example.com/v1` results in requests to
+`https://provider.example.com/v1/images/generations`.
+
+The provider must accept the canonical model IDs listed in
+[Model aliases](#model-aliases). Lilac does not support custom alias-to-model
+mappings in this configuration.
+
+## Configuration
+
+Image routing requires a v2 `core-config.yaml` and two existing environment
+variables.
+
+Set the provider in `$DATA_DIR/core-config.yaml`. `DATA_DIR` defaults to the
+repository's `data/` directory.
+
+```yaml
+configVersion: 2
+
+tools:
+  generate:
+    image:
+      provider: openai-compatible
+```
+
+Set the endpoint and API key in the environment of the core runtime or
+standalone tool bridge:
+
+```dotenv
+OPENAI_COMPATIBLE_BASE_URL=https://provider.example.com/v1
+OPENAI_COMPATIBLE_API_KEY=replace-with-your-api-key
+```
+
+The API key is sent as an `Authorization: Bearer` header. The endpoint is an
+operator-controlled trust boundary: image prompts, source images, and masks are
+sent to it when `generate.image` is called.
+
+Restart the runtime or standalone tool bridge after changing environment
+variables.
+
+## Model aliases
+
+Callers continue to use Lilac's existing aliases. In OpenAI-compatible mode,
+Lilac sends the corresponding canonical model ID to the provider.
+
+| Lilac alias | Canonical model ID sent upstream |
+| --- | --- |
+| `gpt-5-image` | `gpt-image-1.5` |
+| `nanobanana` | `google/gemini-2.5-flash-image` |
+| `nanobanana-2` | `google/gemini-3.1-flash-image-preview` |
+| `nanobanana-pro` | `google/gemini-3-pro-image-preview` |
+| `grok-imagine-image` | `grok-imagine-image` |
+| `grok-imagine-image-pro` | `grok-imagine-image-pro` |
+
+All aliases route through the same configured endpoint. Routing cannot be
+enabled for only one alias.
+
+## Start the standalone tool server
+
+Build and start the standalone tool bridge:
+
+```bash
+cd apps/tool-bridge
+bun run build
+bun index.ts
+```
+
+In another terminal, list the available tools and aliases:
+
+```bash
+./apps/tool-bridge/dist/index.js --list
+```
+
+Use `TOOL_SERVER_BACKEND_URL` when the bridge listens on a non-default address:
+
+```bash
+TOOL_SERVER_BACKEND_URL=http://127.0.0.1:42069 \
+  ./apps/tool-bridge/dist/index.js --list
+```
+
+## Generate an image
+
+```bash
+./apps/tool-bridge/dist/index.js generate.image \
+  --prompt="A rainy Taipei street at night" \
+  --model=gpt-5-image \
+  --size=1024x1024 \
+  --output-dir=./output \
+  --output=json
+```
+
+The command writes the generated image to the output directory and returns its
+path, byte count, MIME type, requested Lilac alias, and provider warnings.
+
+Alias-specific validation still applies. For example, unsupported GPT image
+sizes and unsupported Grok mask combinations are rejected before an HTTP
+request is sent.
+
+## Edit an image
+
+For structured inputs such as source images and masks, use a JSON input file:
+
+```json
+{
+  "prompt": "Replace the background with a mountain lake",
+  "model": "gpt-5-image",
+  "inputImages": ["./input.png"],
+  "maskImage": "./mask.png",
+  "outputDir": "./output"
+}
+```
+
+Run it with:
+
+```bash
+./apps/tool-bridge/dist/index.js generate.image --input=@edit-image.json --output=json
+```
+
+Lilac sends edits as multipart requests to `/images/edits`. The provider must
+support the selected model and edit operation.
+
+## Default routing
+
+To restore the built-in provider-aware routing, set:
+
+```yaml
+tools:
+  generate:
+    image:
+      provider: default
+```
+
+Omitting the field also defaults to `default`. In that mode, Lilac uses its
+existing OpenAI, OpenRouter, and xAI provider selection behavior.
+
+## Errors and fallback behavior
+
+- If `provider` is `openai-compatible` but
+  `OPENAI_COMPATIBLE_BASE_URL` is missing, tool discovery remains available,
+  but an actual `generate.image` call fails before sending an HTTP request.
+- Provider HTTP errors and malformed responses are returned to the caller.
+- Lilac sends one generation attempt and does not retry through an official
+  provider.
+- Lilac does not automatically fall back to OpenAI, OpenRouter, or xAI after
+  OpenAI-compatible routing is selected.
+- `generate.video` remains independent of this image-provider setting.
+
+## Troubleshooting
+
+### The provider returns model-not-found
+
+Confirm that the provider recognizes the canonical model ID from the alias
+table. Custom model-ID mappings are not supported.
+
+### The request returns 404
+
+Check whether the base URL includes the provider's API version prefix, usually
+`/v1`. Lilac appends `/images/generations` or `/images/edits` to the configured
+base URL.
+
+### Image generation is not using the third-party endpoint
+
+Confirm all of the following:
+
+1. `core-config.yaml` has `configVersion: 2`.
+2. `tools.generate.image.provider` is `openai-compatible`.
+3. The runtime process received `OPENAI_COMPATIBLE_BASE_URL` and
+   `OPENAI_COMPATIBLE_API_KEY`.
+4. The runtime was restarted after changing its environment.
+
+### Image generation fails but video generation still appears
+
+This is expected when the OpenAI-compatible image endpoint is missing or
+invalid. Image-provider configuration does not control `generate.video`.

--- a/packages/utils/config-templates/core-config.example.yaml
+++ b/packages/utils/config-templates/core-config.example.yaml
@@ -26,6 +26,17 @@ tools:
   media:
     maxInlineBytesPerPart: 10MiB
     maxInlineBytesTotal: 20MiB
+  generate:
+    image:
+      # Transport routing switch for generate.image.
+      # - default: use built-in provider-aware aliases.
+      # - openai-compatible: route all generate.image calls through the
+      #   OpenAI-compatible provider configured via OPENAI_COMPATIBLE_BASE_URL
+      #   and OPENAI_COMPATIBLE_API_KEY.
+      # Aliases and adapters remain unchanged; all aliases route together.
+      # Canonical model IDs are fixed. Selecting third-party routing has no
+      # automatic fallback.
+      provider: default
 
 plugins:
   disabled: []

--- a/packages/utils/core-config/types.ts
+++ b/packages/utils/core-config/types.ts
@@ -97,6 +97,11 @@ export type UniversalCoreConfig = {
 
   tools: {
     fsBackend: "fff" | "node-rg";
+    generate: {
+      image: {
+        provider: "default" | "openai-compatible";
+      };
+    };
     web: {
       extract: {
         providers: Array<"tavily" | "exa" | "firecrawl">;

--- a/packages/utils/core-config/v1.ts
+++ b/packages/utils/core-config/v1.ts
@@ -714,6 +714,11 @@ export function parseCoreConfigV1ToUniversal(
     tools: {
       ...toolsRest,
       fsBackend: parsed.tools.fsBackend,
+      generate: {
+        image: {
+          provider: "default",
+        },
+      },
       inspect: {
         model: "google/gemini-3-flash",
       },

--- a/packages/utils/core-config/v2.ts
+++ b/packages/utils/core-config/v2.ts
@@ -282,6 +282,15 @@ const durationMsSchema = z.preprocess(parseFriendlyDurationMs, z.number().int().
 const toolsSchema = z
   .object({
     fsBackend: z.enum(["fff", "node-rg"]).default("fff"),
+    generate: z
+      .object({
+        image: z
+          .object({
+            provider: z.enum(["default", "openai-compatible"]).default("default"),
+          })
+          .default({ provider: "default" }),
+      })
+      .default({ image: { provider: "default" } }),
     web: webExtractConfigSchema,
     inspect: z
       .object({
@@ -336,6 +345,11 @@ const toolsSchema = z
   })
   .default({
     fsBackend: "fff",
+    generate: {
+      image: {
+        provider: "default",
+      },
+    },
     web: {
       extract: {
         providers: ["tavily"],

--- a/packages/utils/tests/core-config.versioning.test.ts
+++ b/packages/utils/tests/core-config.versioning.test.ts
@@ -3,6 +3,115 @@ import { describe, expect, it } from "bun:test";
 import { parseCoreConfig, readCoreConfigVersion } from "../core-config";
 
 describe("core config versioning", () => {
+  it("preserves explicit v1 web tool settings", async () => {
+    // Given
+    const raw = {
+      configVersion: 1,
+      tools: {
+        web: {
+          extract: {
+            providers: ["exa", "firecrawl"],
+          },
+          fetch: {
+            mode: "browser",
+          },
+        },
+      },
+    };
+
+    // When
+    const parsed = await parseCoreConfig(raw);
+
+    // Then
+    expect(parsed.tools.web.extract.providers).toEqual(["exa", "firecrawl"]);
+    expect(parsed.tools.web.fetch.mode).toBe("browser");
+  });
+
+  it("preserves explicit v2 batch and media tool settings", async () => {
+    // Given
+    const raw = {
+      configVersion: 2,
+      tools: {
+        batch: {
+          maxCalls: 4,
+        },
+        media: {
+          maxInlineBytesPerPart: 1_024,
+          maxInlineBytesTotal: 2_048,
+        },
+      },
+    };
+
+    // When
+    const parsed = await parseCoreConfig(raw);
+
+    // Then
+    expect(parsed.tools.batch.maxCalls).toBe(4);
+    expect(parsed.tools.media).toEqual({
+      maxInlineBytesPerPart: 1_024,
+      maxInlineBytesTotal: 2_048,
+    });
+  });
+
+  it("defaults the v1 universal image provider", async () => {
+    // Given
+    const raw = { configVersion: 1 };
+
+    // When
+    const parsed = await parseCoreConfig(raw);
+
+    // Then
+    expect(parsed.tools.generate.image.provider).toBe("default");
+  });
+
+  it("defaults an omitted v2 image provider", async () => {
+    // Given
+    const raw = { configVersion: 2 };
+
+    // When
+    const parsed = await parseCoreConfig(raw);
+
+    // Then
+    expect(parsed.tools.generate.image.provider).toBe("default");
+  });
+
+  it("accepts the v2 openai-compatible image provider", async () => {
+    // Given
+    const raw = {
+      configVersion: 2,
+      tools: {
+        generate: {
+          image: {
+            provider: "openai-compatible",
+          },
+        },
+      },
+    };
+
+    // When
+    const parsed = await parseCoreConfig(raw);
+
+    // Then
+    expect(parsed.tools.generate.image.provider).toBe("openai-compatible");
+  });
+
+  it("rejects an unknown v2 image provider", async () => {
+    // Given
+    const raw = {
+      configVersion: 2,
+      tools: {
+        generate: {
+          image: {
+            provider: "unknown",
+          },
+        },
+      },
+    };
+
+    // When / Then
+    await expect(parseCoreConfig(raw)).rejects.toThrow();
+  });
+
   it("treats missing configVersion as v1", async () => {
     expect(readCoreConfigVersion({})).toBe(1);
 


### PR DESCRIPTION
## Summary

Adds an opt-in switch that routes `generate.image` through a single **OpenAI-compatible** provider instead of the built-in OpenAI / OpenRouter / xAI selection. This lets an operator point image generation at their own gateway (LiteLLM, new-api, vLLM, a corporate proxy, …) without touching model aliases or caller code.

Default behavior is unchanged. The feature is off unless `core-config.yaml` explicitly opts in.

```yaml
configVersion: 2
tools:
  generate:
    image:
      provider: openai-compatible # default | openai-compatible
```

Plus the two existing env vars: `OPENAI_COMPATIBLE_BASE_URL`, `OPENAI_COMPATIBLE_API_KEY`.

## Design

### The idea: swap the transport, keep everything else

The existing image support is a table of `IMAGE_MODEL_DESCRIPTORS`, one per alias, each knowing how to build its own model object from whichever provider is configured. The alias is the stable public contract (`nanobanana-2`), while the provider-specific slug is an internal detail (`google/gemini-3.1-flash-image-preview`).

This PR adds one field to that descriptor — `openAICompatibleModelId`, the canonical ID to send upstream — and one branch in resolution:

```ts
function getAvailableImageModels(provider: "default" | "openai-compatible" = "default") {
  const providers = getModelProviders();
  if (provider === "openai-compatible") {
    // …guard on base URL…
    return resolveAvailableModels(
      IMAGE_MODEL_DESCRIPTORS.map((descriptor) => ({
        ...descriptor,
        createModel: () => compatibleProvider.imageModel(descriptor.openAICompatibleModelId),
      })),
      providers,
    );
  }
  return resolveAvailableModels(IMAGE_MODEL_DESCRIPTORS, providers);
}
```

Only `createModel` is overridden. Every descriptor keeps its own `validateInput`, so per-alias validation (GPT size rules, nanobanana ratios, grok's mask/size restrictions) still runs **before** any HTTP request, in exactly the same order as the default path. That's the property that makes this cheap: the routing change cannot alter validation, because validation isn't part of what gets swapped.

### Deliberate design decisions worth reviewing

**No automatic fallback.** Once you opt in, a failure is a failure — there is no silent retry against OpenAI/OpenRouter/xAI. `maxRetries: 0` is set for this mode. Rationale: the endpoint is an operator-chosen trust boundary, and quietly failing over would send prompts and source images somewhere the operator didn't select. A loud error is the safer default. This is the decision I'd most like a second opinion on.

**All aliases route together.** There is no per-alias routing and no custom alias→model mapping. One switch, one endpoint. Keeps the config surface small; the cost is that you can't split traffic.

**Discovery stays available when the endpoint is unconfigured.** If `provider: openai-compatible` but `OPENAI_COMPATIBLE_BASE_URL` is missing, `list()` still advertises the image aliases and `generate.video` keeps working; only an actual `generate.image` call throws. Rationale: tool discovery shouldn't collapse because of one misconfigured modality. Debatable — the alternative is hiding the tool, which trades a clear runtime error for a confusing absence.

**v1 config is frozen.** Per `AGENTS.md`, `coreConfigInputSchemaV1` is untouched; v1 gets the `default` fallback in `parseCoreConfigV1ToUniversal` and cannot opt in. v2-only feature.

### Config plumbing

`Generate` needs config at call time, so it takes `getConfig` instead of reading a global. `apps/tool-bridge` previously built its plugin manager with `runtime: {}` — a new `createToolBridgePluginManager` now supplies `getConfig`, so the standalone bridge and the core runtime resolve the provider identically.

## Review findings addressed in this PR

I reviewed the original branch before rebasing and found four issues. Each is fixed in its own commit, and each is worth a look:

**1. Silent misrouting when the runtime omits config** (`53bd47ac`) — the most serious one. `createBuiltinGeneratePlugin` passed `getConfig: undefined` when the runtime supplied neither `config` nor `getConfig`. `Generate` then assumes `"default"`, so a `core-config.yaml` requesting `openai-compatible` was **silently ignored and prompts went to the built-in providers instead of the operator's endpoint**. Both production call sites pass `getConfig` today, so this was latent rather than live — but the failure mode is silent exfiltration to the wrong endpoint, which is exactly what this feature exists to control. Now falls back to reading core-config from disk. The added test fails without the fix (verified by reverting).

**2. `aspectRatio` is silently dropped upstream** (`63fe9b4c`) — a real behavioral difference the docs previously papered over by claiming behavior was "unchanged". The OpenAI-compatible image API has no aspect-ratio parameter, so `@ai-sdk/openai-compatible` discards it and emits an `unsupported` warning. Verified against a live local server:

```
REQUEST BODY >>> {"model":"google/gemini-3.1-flash-image-preview","prompt":"wide shot","n":1,"response_format":"b64_json"}
WARNINGS     >>> [{"type":"unsupported","feature":"aspectRatio", …}]
```

Consequence: `gpt-image-2`/`gpt-5-image` are fine (Lilac converts ratio→size first), but `nanobanana*` and `grok-imagine-image*` are ratio-driven with no `size` equivalent — and grok rejects `size` outright — so in this mode they can only produce the provider's default ratio. Now documented as a known limitation, with two tests pinning both halves of the behavior.

**3. Typecheck break from the rebase** (`676eed42`) — `main` added `gpt-image-2` and `nanobanana-2-lite` after this branch forked. Both were missing the now-required `openAICompatibleModelId`, breaking `tsc` in `apps/core`. Restored using the same canonical IDs the default path uses.

**4. Stale characterization tests** (`0239385f`) — `main` also changed `list()` to report fallback order, so two expectations no longer described upstream behavior.

### Also dropped during the rebase

The original branch's README carried PR-status tables, local test counts, and self-referential "branch-only / no PR yet" prose (introduced by a merge commit, not the feature commits), and its stale doc files would have reverted `workflows.maxActiveRuns` and the schema-4 migration notes. This PR is cherry-picked onto current `main`, so **the README diff is now a single additive line** and the 45 files of `.omo/` newline churn are gone.

## Testing

New coverage, driven against **real `Bun.serve` endpoints** rather than mocks, so the assertions are on actual wire format:

- **`generate-image-openai-compatible.test.ts`** — all 8 alias→canonical mappings; `POST /v1/images/generations` JSON body and `Bearer` auth; multipart `POST /v1/images/edits` with image+mask; validation rejected before HTTP (request count `0`); HTTP 500 propagates after **exactly one** request (proving no retry/fallback); malformed success leaves no file on disk; the two new `aspectRatio` cases.
- **`generate-registration.test.ts`** — video survives a missing image base URL; the on-disk-provider regression test from finding #1.
- **`core-config.versioning.test.ts`** — v1 fallback, v2 default, v2 opt-in, unknown-value rejection.
- **`create-plugin-manager.test.ts`**, **`generate-construction.test.ts`**, **`generate-image-characterization.test.ts`** — wiring and default-path characterization.

Results on this branch:

| Suite | Result |
| --- | --- |
| `apps/core` | 1372 pass, 1 pre-existing failure |
| `packages/utils` | 268 pass, 0 fail |
| `apps/tool-bridge` | 29 pass, 0 fail |
| `bun run typecheck` (all workspaces) | clean |
| `bun run lint` / `fmt:check` | clean |

The one `apps/core` failure is `heartbeat service > falls back gracefully when quiet-hours timezone is invalid`. **It is pre-existing and unrelated** — I reproduced it on a clean `origin/main` worktree with no changes applied. `fs-search-parity` tests need `bun run build:remote-runner` first; they pass once built.

## Risk

- Default path untouched; feature requires explicit v2 opt-in.
- Config layer follows the frozen-v1 rule; `MIGRATIONS.md`, `PROJECT.md`, `core-config.example.yaml`, and `.env.example` all updated.
- Main residual risk is the intentional no-fallback stance (see Design) and the `aspectRatio` limitation (now documented).

## Reviewer checklist

- Is **no-fallback + `maxRetries: 0`** the right call, or should a failed compatible call fall back to configured official providers?
- Is **discovery-stays-available** with an unconfigured base URL right, or should the image tool be hidden?
- Are the canonical IDs correct for your gateway? Notably `gpt-5-image` → `gpt-image-1.5`.
- Is the `aspectRatio` limitation acceptable as documented, or should ratio-only aliases be **rejected** in this mode rather than silently producing a default ratio?
