### PR TITLE
feat(github): generate canonical reply permalinks

### DIFF
--- a/apps/core/src/github/github-api.ts
+++ b/apps/core/src/github/github-api.ts
@@ -225,6 +225,7 @@ export async function deleteIssueComment(input: {
 }
 
 export async function getIssue(input: { owner: string; repo: string; number: number }): Promise<{
+  id: number;
   title: string;
   body: string | null;
   html_url?: string;

--- a/apps/core/src/github/github-ids.ts
+++ b/apps/core/src/github/github-ids.ts
@@ -47,13 +47,19 @@ export function isGithubIssueTriggerId(input: { sessionId: string; triggerId: st
   return String(thread.number) === input.triggerId;
 }
 
-export function githubMessageUrl(input: { sessionId: string; messageId: string }): string {
+export function githubMessageUrl(input: {
+  sessionId: string;
+  messageId: string;
+  issueId?: number;
+}): string {
   const thread = parseGithubSessionId(input.sessionId);
   const threadUrl = `https://github.com/${encodeURIComponent(thread.owner)}/${encodeURIComponent(thread.repo)}/issues/${thread.number}`;
 
-  return String(thread.number) === input.messageId
-    ? threadUrl
-    : `${threadUrl}#issuecomment-${encodeURIComponent(input.messageId)}`;
+  if (String(thread.number) === input.messageId) {
+    return input.issueId ? `${threadUrl}#issue-${input.issueId}` : threadUrl;
+  }
+
+  return `${threadUrl}#issuecomment-${encodeURIComponent(input.messageId)}`;
 }
 
 export function repoFullName(ref: GithubRepoRef): string {

--- a/apps/core/src/github/github-ids.ts
+++ b/apps/core/src/github/github-ids.ts
@@ -47,6 +47,15 @@ export function isGithubIssueTriggerId(input: { sessionId: string; triggerId: st
   return String(thread.number) === input.triggerId;
 }
 
+export function githubMessageUrl(input: { sessionId: string; messageId: string }): string {
+  const thread = parseGithubSessionId(input.sessionId);
+  const threadUrl = `https://github.com/${encodeURIComponent(thread.owner)}/${encodeURIComponent(thread.repo)}/issues/${thread.number}`;
+
+  return String(thread.number) === input.messageId
+    ? threadUrl
+    : `${threadUrl}#issuecomment-${encodeURIComponent(input.messageId)}`;
+}
+
 export function repoFullName(ref: GithubRepoRef): string {
   return `${ref.owner}/${ref.repo}`;
 }

--- a/apps/core/src/surface/github/output/github-output-stream.ts
+++ b/apps/core/src/surface/github/output/github-output-stream.ts
@@ -3,7 +3,7 @@ import type { SurfaceOutputPart, SurfaceOutputResult, SurfaceOutputStream } from
 
 import { createIssueComment } from "../../../github/github-api";
 import { markGithubAgentComment } from "../../../github/github-comment-marker";
-import { parseGithubSessionId } from "../../../github/github-ids";
+import { githubMessageUrl, parseGithubSessionId } from "../../../github/github-ids";
 
 export class GithubOutputStream implements SurfaceOutputStream {
   private text = "";
@@ -64,7 +64,11 @@ export class GithubOutputStream implements SurfaceOutputStream {
     const replyPrefix = (() => {
       const replyTo = this.opts?.replyTo;
       if (!replyTo || replyTo.platform !== "github") return "";
-      return `In reply to ${replyTo.messageId}:\n\n`;
+      const replyUrl = githubMessageUrl({
+        sessionId: replyTo.channelId,
+        messageId: replyTo.messageId,
+      });
+      return `In reply to ${replyUrl}:\n\n`;
     })();
 
     const body = markGithubAgentComment(`${replyPrefix}${this.text}`);

--- a/apps/core/src/surface/github/output/github-output-stream.ts
+++ b/apps/core/src/surface/github/output/github-output-stream.ts
@@ -1,9 +1,13 @@
 import type { MsgRef, SessionRef, SurfaceAttachment } from "../../types";
 import type { SurfaceOutputPart, SurfaceOutputResult, SurfaceOutputStream } from "../../adapter";
 
-import { createIssueComment } from "../../../github/github-api";
+import { createIssueComment, getIssue } from "../../../github/github-api";
 import { markGithubAgentComment } from "../../../github/github-comment-marker";
-import { githubMessageUrl, parseGithubSessionId } from "../../../github/github-ids";
+import {
+  githubMessageUrl,
+  isGithubIssueTriggerId,
+  parseGithubSessionId,
+} from "../../../github/github-ids";
 
 export class GithubOutputStream implements SurfaceOutputStream {
   private text = "";
@@ -61,15 +65,28 @@ export class GithubOutputStream implements SurfaceOutputStream {
 
     const thread = parseGithubSessionId(this.sessionRef.channelId);
 
-    const replyPrefix = (() => {
-      const replyTo = this.opts?.replyTo;
-      if (!replyTo || replyTo.platform !== "github") return "";
+    const replyTo = this.opts?.replyTo;
+    let replyPrefix = "";
+    if (replyTo?.platform === "github") {
+      const replyThread = parseGithubSessionId(replyTo.channelId);
+      const repliesToIssue = isGithubIssueTriggerId({
+        sessionId: replyTo.channelId,
+        triggerId: replyTo.messageId,
+      });
+      const issue = repliesToIssue
+        ? await getIssue({
+            owner: replyThread.owner,
+            repo: replyThread.repo,
+            number: replyThread.number,
+          })
+        : undefined;
       const replyUrl = githubMessageUrl({
         sessionId: replyTo.channelId,
         messageId: replyTo.messageId,
+        issueId: issue?.id,
       });
-      return `In reply to ${replyUrl}:\n\n`;
-    })();
+      replyPrefix = `In reply to ${replyUrl}:\n\n`;
+    }
 
     const body = markGithubAgentComment(`${replyPrefix}${this.text}`);
     const res = await createIssueComment({

--- a/apps/core/tests/github/github-ids.test.ts
+++ b/apps/core/tests/github/github-ids.test.ts
@@ -12,7 +12,17 @@ describe("githubMessageUrl", () => {
     ).toBe("https://github.com/DF-wu/lilac-mono/issues/47#issuecomment-5124469595");
   });
 
-  it("links the issue or pull request when the message id is the thread number", () => {
+  it("links an issue or pull request body by its database id", () => {
+    expect(
+      githubMessageUrl({
+        sessionId: "DF-wu/lilac-mono#47",
+        messageId: "47",
+        issueId: 5014377739,
+      }),
+    ).toBe("https://github.com/DF-wu/lilac-mono/issues/47#issue-5014377739");
+  });
+
+  it("falls back to the thread URL when an issue database id is unavailable", () => {
     expect(
       githubMessageUrl({
         sessionId: "DF-wu/lilac-mono#47",

--- a/apps/core/tests/github/github-ids.test.ts
+++ b/apps/core/tests/github/github-ids.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import { githubMessageUrl } from "../../src/github/github-ids";
+
+describe("githubMessageUrl", () => {
+  it("links an issue comment from its session and message ids", () => {
+    expect(
+      githubMessageUrl({
+        sessionId: "DF-wu/lilac-mono#47",
+        messageId: "5124469595",
+      }),
+    ).toBe("https://github.com/DF-wu/lilac-mono/issues/47#issuecomment-5124469595");
+  });
+
+  it("links the issue or pull request when the message id is the thread number", () => {
+    expect(
+      githubMessageUrl({
+        sessionId: "DF-wu/lilac-mono#47",
+        messageId: "47",
+      }),
+    ).toBe("https://github.com/DF-wu/lilac-mono/issues/47");
+  });
+});

--- a/apps/core/tests/tool-server-surface.test.ts
+++ b/apps/core/tests/tool-server-surface.test.ts
@@ -2387,6 +2387,7 @@ describe("tool-server surface", () => {
 
     const githubApi: GithubSurfaceApi = {
       getIssue: async () => ({
+        id: 12,
         title: "t",
         body: "b",
         user: { login: "alice", id: 1 },

--- a/docs/github-reply-permalinks.md
+++ b/docs/github-reply-permalinks.md
@@ -1,0 +1,92 @@
+# GitHub Reply Permalinks
+
+## Purpose
+
+GitHub relay replies include an `In reply to ...` reference. The reference is
+rendered as a clickable permalink to the referenced issue or pull request body,
+or to the specific issue comment. This lets readers navigate directly to the
+source without searching for an internal message ID.
+
+## Existing Reference Contract
+
+This feature keeps the existing `GithubMsgRef` and event-bus contracts
+unchanged:
+
+- `channelId` is `<owner>/<repo>#<thread-number>`.
+- An issue or pull request body reference stores the thread number in
+  `messageId`.
+- A comment reference stores the GitHub issue-comment database ID in
+  `messageId`.
+
+`messageId` therefore has two established meanings. The URL builder must
+first determine which target is referenced before choosing the GitHub anchor.
+Keeping this decision at the GitHub output boundary avoids changes to relay
+snapshots, reanchoring, the event bus, and adapter boundaries.
+
+## URL Construction
+
+`githubMessageUrl({ sessionId, messageId, issueId })` parses the repository and
+thread number from `sessionId`, then creates this common base URL:
+
+```text
+https://github.com/<owner>/<repo>/issues/<thread-number>
+```
+
+The target-specific rules are:
+
+| Target | Detection | Result |
+| --- | --- | --- |
+| Issue or pull request body | `messageId === thread number` and `issueId` is available | `<base>#issue-<issue database id>` |
+| Issue or pull request body | `messageId === thread number` and `issueId` is unavailable | Bare `<base>` URL |
+| Issue comment | `messageId !== thread number` | `<base>#issuecomment-<comment database id>` |
+
+GitHub accepts the `/issues/<number>` base for pull requests as well. It
+redirects to the pull request URL while preserving the fragment, so the
+reference does not need to carry an additional issue-or-PR discriminator.
+
+Repository components and comment IDs are encoded before being placed in the
+URL. The numeric thread number and body issue ID originate from the parsed
+GitHub reference/API response.
+
+## API and Performance
+
+GitHub uses different object identities for body and comment anchors:
+
+- `#issue-<id>` requires the issue or pull request database ID.
+- `#issuecomment-<id>` uses the existing issue-comment database ID.
+
+`getIssue()` now exposes the issue database `id`. The output stream calls
+`getIssue()` only when the reply target is the thread body. Comment replies use
+their existing `messageId` directly and do not add an API request.
+
+If the body lookup fails to provide an ID, permalink generation falls back to
+the bare thread URL. The resulting reply remains readable and points to the
+correct issue or pull request without emitting an invalid anchor.
+
+## Validation
+
+The implementation is covered by `apps/core/tests/github/github-ids.test.ts`,
+including comment permalinks, issue and pull request body permalinks, and the
+missing-body-ID fallback. The tool-server surface fixture also includes the
+new `getIssue().id` field.
+
+Validated on the feature branch:
+
+- `bun test ./apps/core/tests/github/github-ids.test.ts ./apps/core/tests/tool-server-surface.test.ts` — 49 passed
+- `bunx tsc -p apps/core/tsconfig.json --noEmit` — passed
+- `bun run fmt:check` — passed
+- Earlier focused validation — 61 passed; Oxlint reported 0 warnings and 0 errors
+
+A later lint rerun was blocked before source analysis because the local Node
+runtime could not load `scripts/oxlint-plugins/test-waits.mts`
+(`ERR_UNKNOWN_FILE_EXTENSION`). This is an environment/tooling limitation, not
+a source diagnostic.
+
+## Future Schema Option
+
+A coordinated schema change could add an explicit target kind and canonical
+`html_url` to `GithubMsgRef`. That would remove the current `messageId`
+overload and avoid the body lookup, but it would require synchronized changes
+across the event bus, relay snapshots, reanchoring, and adapter boundaries.
+This feature deliberately preserves the current contract and limits canonical
+URL generation to the GitHub output boundary.


### PR DESCRIPTION
## Summary

- render GitHub reply references as clickable permanent links
- distinguish issue/PR body anchors (`#issue-<database-id>`) from comment anchors (`#issuecomment-<comment-id>`)
- resolve the issue database ID only for body replies and retain the bare thread URL as a best-effort fallback

## Implementation details

`GithubMsgRef.messageId` is overloaded today: issue/PR body references store the thread number, while comment references store the issue-comment database ID. GitHub's anchors use different object identities, so one common prefix cannot produce correct links for both targets.

For comment replies, the output stream uses the existing message ID directly and does not add an API request. For body replies, it calls `getIssue()` to obtain the issue database ID and emits `#issue-<id>`. The common `/issues/<number>` base also works for pull requests because GitHub redirects it to `/pull/<number>` while preserving the fragment.

This intentionally keeps the current message-reference contract unchanged. A future schema change could preserve an explicit target kind and canonical `html_url`, but that would require coordinated changes across the event bus, relay snapshots, reanchor handling, and adapter boundaries.

## Validation

- `bun test ./apps/core/tests/github/github-ids.test.ts ./apps/core/tests/tool-server-surface.test.ts` (49 passed)
- `bunx tsc -p apps/core/tsconfig.json --noEmit` (passed)
- `bun run fmt:check` (passed)
- Earlier branch validation: 61 focused tests passed; Oxlint reported 0 warnings and 0 errors
- Current lint rerun is blocked before source analysis because the local Node runtime cannot load `scripts/oxlint-plugins/test-waits.mts` (`ERR_UNKNOWN_FILE_EXTENSION`)

Closes #48
