### PR TITLE
docs: rewrite maintained-fork project guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,295 +1,361 @@
-# Lilac Monorepo
+# Lilac Mono
 
 <p align="center">
-  <strong>Bun monorepo for a Redis-backed AI agent runtime with Discord ingress, optional Telegram and GitHub ingress, layered tools, and durable workflow resume.</strong>
+  <strong>面向 Discord、Telegram、GitHub 與本機終端的事件驅動 AI Agent Runtime</strong>
 </p>
 
 <p align="center">
-  <a href="./PROJECT.md">Architecture</a>
-  ·
-  <a href="./AGENTS.md">Agent Guide</a>
-  ·
-  <a href="./apps/acp-controller/README.md">ACP CLI</a>
-  ·
-  <a href="#quick-differences-from-upstream">Differences</a>
-  ·
-  <a href="https://github.com/stanley2058/lilac-mono">Upstream</a>
+  <a href="https://github.com/DF-wu/lilac-mono/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/DF-wu/lilac-mono/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/stanley2058/lilac-mono"><img alt="Upstream" src="https://img.shields.io/badge/upstream-stanley2058%2Flilac--mono-6f42c1"></a>
+  <a href="./package.json"><img alt="Bun 1.3.14" src="https://img.shields.io/badge/Bun-1.3.14-14151a?logo=bun&logoColor=white"></a>
+  <a href="./LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-2ea44f"></a>
 </p>
 
-Lilac is an event-driven runtime for request-scoped LLM work. It keeps surface ingress, routing, agent execution, tool access, and workflow resume in one system instead of splitting them across separate bots, scripts, and operator glue.
+<p align="center">
+  <a href="#選擇執行方式">選擇執行方式</a> ·
+  <a href="#本-fork-的主要差異">Fork 差異</a> ·
+  <a href="#快速開始">快速開始</a> ·
+  <a href="#core-surfaces">Surfaces</a> ·
+  <a href="./docs/README.md">完整文件</a> ·
+  <a href="./PROJECT.md">架構細節</a>
+</p>
 
-This repository is a maintained fork of [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono). The fork context matters: most architecture and runtime concepts still follow upstream, while this fork adds a small set of operator-focused changes for GitHub automation, container delivery, and ACP reliability.
+> [!IMPORTANT]
+> 這是以 Git history 與 `upstream` remote 持續追蹤 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的 downstream fork，不是上游官方發行版。本專案定期合併上游更新，同時維護 Telegram、相容式圖像路由、GitHub 回覆連結與部署自動化等獨立功能。
 
-## Quick Differences From Upstream
+Lilac 把平台訊息、路由、模型執行、工具、Skills 與可恢復工作流程放在同一套 runtime 中。Monorepo 內同時提供完整的 **Core** 服務，以及不需要 Redis 的本機 coding agent **Mini Lilac**。
 
-If you already know upstream Lilac, start here. This fork keeps the same Bun workspace layout and event-driven runtime model, but currently differs in these practical areas:
+## 選擇執行方式
 
-| Area | This fork adds or changes | Why it matters |
+| | Core | Mini Lilac |
 | --- | --- | --- |
-| GitHub issue/PR comments | `/lilac` and `@bot` triggers are parsed from the first non-empty, non-quoted, non-code-fenced content line. Agent-authored comments are marked with `<!-- lilac:agent-comment -->` and ignored by webhook ingress. | Users can invoke the agent from GitHub comments more predictably, while avoiding self-trigger loops. |
-| GitHub surface output | GitHub comments created by the adapter, output stream, or `surface.messages.send` are automatically marked as agent comments. | Outbound GitHub replies remain machine-identifiable across both runtime output and tool-driven messages. |
-| ACP controller robustness | Detached ACP runs treat Linux zombie worker processes as dead, and cancellation closes the harness client so workers can settle instead of hanging indefinitely. | Long-running local/automation prompt workflows recover more cleanly from stuck harness transports. |
-| Container delivery | GitHub Actions build and publish GHCR images for `catalina` and `claudia` variants, with `latest` pointing at the `catalina` image. The Docker image also includes `rsync` and the upstream `smart-search` CLI runtime. | Operators can consume prebuilt images and have a more complete shell toolbox plus an official `smart-search` runtime inside the container. |
-| Upstream maintenance | A scheduled GitHub Actions workflow checks `stanley2058/lilac-mono` every 6 hours and merges upstream `main` when possible, then triggers image rebuilds. | This fork is intended to stay close to upstream while keeping local operational patches visible. |
+| 適合情境 | 長駐 bot、多平台協作、自動化與 durable workflows | 在本機專案中使用互動式 coding agent |
+| 入口 | Discord、Telegram、GitHub webhook、HTTP tool server | Terminal TUI、HTTP/SSE API |
+| 狀態儲存 | Redis Streams + SQLite + `DATA_DIR` | SQLite + `$XDG_STATE_HOME/mini-lilac` |
+| 主要依賴 | Bun、Redis；建議使用 Docker Compose | Bun 與系統 `flock`，不需要 Redis |
+| 開始方式 | 從本 repo 設定並啟動 Core | 從本 repo build 並直接執行 Mini Lilac |
 
-The fork-specific code is intentionally small and easy to audit. Useful entry points are `apps/core/src/github/github-comment-marker.ts`, `apps/core/src/github/webhook/github-webhook-server.ts`, `apps/core/src/surface/github/`, `apps/acp-controller/controller.ts`, and `.github/workflows/`.
+Mini Lilac 是上游持續發展的產品，本 fork 會隨上游同步。若你要部署聊天平台 bot 或工作流程服務，選 Core；若只要在終端操作本機專案，Mini Lilac 是較短的路徑。
 
-## What This Repo Does
+## 本 Fork 的主要差異
 
-- Receives work from **Discord**, optional **Telegram**, and optional **GitHub issue/PR webhook** flows.
-- Routes requests through a **typed Redis Streams event bus**.
-- Runs agent turns with **local tools**, **HTTP tool-server callables**, and **on-disk skills**.
-- Sends results back to Discord, Telegram, and GitHub surfaces.
-- Supports **pause/resume**, scheduled wakeups, and long-lived workflows.
-- Ships operator-facing tooling through the **`tools` bridge** and **`lilac-acp` controller**.
+以下只列出目前仍與上游不同的行為。完整依據、限制與已回饋上游的項目見 [`docs/fork-differences.md`](./docs/fork-differences.md)。
 
-## Core Capabilities
+| 領域 | 本 fork 提供的差異 | 重要限制 |
+| --- | --- | --- |
+| Telegram surface | DMs、群組、forum topics、串流 HTML 回覆、取消、reaction、command menu、outbound attachments、workflow cards 與同 surface tools | 預設停用；沒有 inbound attachment bytes；僅 long polling |
+| OpenAI-compatible 圖像路由 | 將既有 `generate.image` aliases 統一路由到 operator 指定的 OpenAI-compatible endpoint | 僅 `configVersion: 2`；無自動 fallback 或自訂 alias mapping |
+| GitHub 回覆 UX | `In reply to` 可直接連到 issue/PR body 或指定 comment 的 canonical permalink | GitHub comment self-loop 防護已被上游接收，不再列為 fork-only |
+| Custom media plugin | 可部署的 Level 2 image/video plugin 範例，示範嚴格設定與檔案安全處理 | Plugin 是 trusted in-process code；restricted caller 目前不能使用 external callables |
+| 維運與交付 | 每 6 小時檢查 upstream、GHCR `catalina`/`claudia` tags、ACP detached-run 強化 | 自動合併發生衝突時仍需人工處理 |
 
-### 1. Runtime-first architecture
+## 架構概覽
 
-The center of gravity is `apps/core/`. That runtime wires together Redis, the event bus, Discord ingress, GitHub webhook ingress, routing, agent execution, tool serving, workflow services, transcript/search stores, and heartbeat-driven background prompting.
+### Core request flow
 
-### 2. Typed event model
+```mermaid
+flowchart LR
+    Discord[Discord] --> Bus[Typed Redis Streams bus]
+    Telegram[Telegram] --> Bus
+    Bus --> Router[Surface router]
+    GitHub[GitHub webhook] --> Request[Request queue]
+    Router --> Request
+    Request --> Agent[Agent runner]
+    Agent --> L1[Level 1 local tools]
+    Agent --> L2[Level 2 HTTP tools]
+    Agent --> Skills[Level 3 skills]
+    Agent --> Output[Request-scoped output]
+    Output --> Discord
+    Output --> Telegram
+    Output --> GitHub
+    Workflow[Durable workflow engine] <--> Request
+```
 
-`packages/event-bus/` defines the canonical event contract and Redis Streams transport used across ingress, routing, execution, and output delivery.
+Core 的平台 adapter 會把事件送入 typed bus。Router 建立或更新 request，agent runner 再使用模型、工具與 Skills 執行，最後由 output relay 將結果送回原 surface。GitHub webhook 可直接建立 request。
 
-### 3. Layered tools and skills
+Durable workflow engine 使用相同 request bus，並以 SQLite journal 保存 trigger、wait、sleep、subagent 與恢復資訊。完整 topic、queue mode、權限與啟停順序見 [`PROJECT.md`](./PROJECT.md)。
 
-The runtime exposes three capability layers:
+### Fork maintenance flow
 
-- **Local tools** such as shell, file reads, search, and patching.
-- **Tool-server namespaces** for web, workflow, surface, attachments, onboarding, generation, summarize, SSH, and related runtime operations.
-- **On-disk skills** that can be discovered and loaded into runs when needed.
+```mermaid
+flowchart LR
+    Upstream[stanley2058/lilac-mono main] -->|scheduled check every 6 hours| Sync[Sync Upstream workflow]
+    Sync -->|clean merge| Fork[DF-wu/lilac-mono main]
+    Features[Fork features and fixes] --> Fork
+    Fork --> CI[CI]
+    Fork --> Images[GHCR image workflow]
+```
 
-### 4. Durable workflows
+## 快速開始
 
-The repo includes workflow services for wait-for-reply, send-and-wait, scheduling, cancellation, and resume. Discord and Telegram reply waits are bound to the authenticated originating session and user; Telegram workflow delivery also rechecks the current chat allowlist before firing and before every progress-card write. This is built into the runtime rather than bolted on as a separate job system.
+### Mini Lilac：本機 coding agent
 
-### 5. Operator tooling
+Mini Lilac 是最短的互動式使用路徑。套件目前尚未發布到 public npm registry，請從 checkout build 並直接執行；Server 預設只監聽 `127.0.0.1:8090`，TUI 必須在真正的 terminal 中執行。
 
-Two supporting apps matter operationally:
+```bash
+git clone https://github.com/DF-wu/lilac-mono.git
+cd lilac-mono
+bun install --frozen-lockfile
+cd apps/mini-lilac
+bun run build
 
-- `apps/tool-bridge/`: builds the `tools` bridge and standalone tool-server entrypoints.
-- `apps/acp-controller/`: builds `lilac-acp`, a CLI for ACP harness discovery, session inspection, and detached prompt execution.
+./dist/main.js server init
+./dist/main.js server auth codex
+./dist/main.js server
+```
 
-## How It Works
+在另一個 terminal 中，進入要操作的專案：
 
-The runtime flow is:
+```bash
+cd /path/to/your/project
+/path/to/lilac-mono/apps/mini-lilac/dist/main.js
+```
 
-1. Discord adapter events enter through the surface bridge.
-2. The router turns Discord events into request messages.
-3. GitHub webhook handlers can publish request messages directly.
-4. The agent runner executes with models, tools, and skills.
-5. Output is delivered back to Discord or GitHub through the surface layer.
-6. Workflow services can resume work later when time or user input arrives.
+確認 server：
 
-For the full system mental model, terminology, and file-level architecture, see [`PROJECT.md`](./PROJECT.md).
+```bash
+curl -fsS http://127.0.0.1:8090/api/mini-lilac/healthz
+```
+
+設定檔、provider、API key、Codex OAuth、遠端 listener 認證與 TUI 操作見 [`apps/mini-lilac/README.md`](./apps/mini-lilac/README.md) 與 [`apps/mini-lilac-server/README.md`](./apps/mini-lilac-server/README.md)。
+
+### Core：Docker Compose
+
+需求：Docker Compose、Bun 1.3.14、有效的 `DISCORD_TOKEN`，以及至少一組符合 `models.main` 設定的 model provider credential。目前 Core 啟動時仍會連線 Discord；即使只使用 Telegram、GitHub 或 tool server，Discord token 仍是必要設定。各 surface 的 allowlist 依然採 fail-closed 設計。
+
+```bash
+git clone https://github.com/DF-wu/lilac-mono.git
+cd lilac-mono
+bun install
+
+cp .env.example .env
+chmod 600 .env
+mkdir -p data
+cp packages/utils/config-templates/core-config.example.yaml data/core-config.yaml
+
+cat > compose.override.yaml <<'YAML'
+services:
+  lilac:
+    env_file:
+      - .env
+YAML
+```
+
+啟動前請完成兩件事：
+
+1. 在 `.env` 設定 `DISCORD_TOKEN` 與 `data/core-config.yaml` 所選 model provider 的 credential。Stock `compose.yaml` 不會傳入 provider credentials；上面的 `compose.override.yaml` 透過 `env_file` 明確傳入 `.env`。
+2. 在 `data/core-config.yaml` 設定 Discord allowlist，並啟用與限制其他要使用的 surface。
+
+```bash
+docker compose up -d --build --wait --wait-timeout 120
+bun run docker:verify
+docker compose ps
+curl -fsS http://localhost:8080/readyz
+```
+
+`compose.yaml` 同時啟動 Redis，並把 `./data` 掛載到 `/data`。正式部署、operator token、UID、持久化與診斷方式見 [`docs/docker-deployment.md`](./docs/docker-deployment.md)。
+
+> [!WARNING]
+> Core tool server 沒有一般用途的 public HTTP authentication。請將 `8080` 保留在可信任的主機或網路邊界，不要直接暴露到公網。
+
+### Core：從 source 執行
+
+先安裝 dependencies 並準備可連線的 Redis：
+
+```bash
+bun install
+docker run --rm -d --name lilac-source-redis -p 127.0.0.1:6380:6379 redis:7-alpine
+
+export REDIS_URL=redis://127.0.0.1:6380
+export DATA_DIR="$PWD/data"
+export LL_TOOL_SERVER_PORT=8080
+bun apps/core/src/runtime/main.ts
+```
+
+Core 必須有 `REDIS_URL`、`DISCORD_TOKEN` 與有效的 model 設定。Telegram 與 GitHub 可以不啟用，但目前 Discord adapter 仍會在 Core 啟動時連線；Discord allowlist 可以保持空白以忽略所有 Discord traffic。
+
+## Core Surfaces
+
+| Surface | 最低設定 | 預設保護 | 詳細文件 |
+| --- | --- | --- | --- |
+| Discord | `DISCORD_TOKEN`；設定 `allowedChannelIds` 或 `allowedGuildIds` | 兩個 allowlist 都空時忽略所有 Discord traffic | [`core-config.example.yaml`](./packages/utils/config-templates/core-config.example.yaml) |
+| Telegram | `configVersion: 2`、`enabled: true`、`TELEGRAM_BOT_TOKEN`、`allowedChatIds` | 預設停用；空 chat allowlist 時忽略所有 chats | [`docs/telegram-surface.md`](./docs/telegram-surface.md) |
+| GitHub | GitHub App auth、`GITHUB_WEBHOOK_SECRET`、可被 GitHub 連到的 HTTPS/reverse proxy；user token 是可選的 preferred outbound identity | 沒有 GitHub App secret 時整個 surface 不啟動；signature 不符回傳 `401` | [`docs/github-reply-permalinks.md`](./docs/github-reply-permalinks.md) |
+
+GitHub webhook 預設監聽 port `8787`、path `/github/webhook`。Stock Compose 沒有轉送或公開 GitHub webhook 的環境與 port，因此 production deployment 必須自行補上 reverse proxy、environment 與 network wiring。
+
+Webhook secret 只驗證 inbound request；目前 runtime 以 GitHub App secret 作為整個 surface 的啟用條件。先設定 App，再視需要加入 user token 作為 preferred outbound identity。可用 operator-only onboarding 查看兩者參數：
+
+```bash
+docker compose exec -T lilac /usr/local/bin/tools --operator --help onboarding.github_app
+docker compose exec -T lilac /usr/local/bin/tools --operator --help onboarding.github_user_token
+```
+
+Telegram 支援完整對話路徑、workflow cards 與同 surface tools，但平台能力不等於 Discord。Inbound media、history、reaction 與 search 差異請以 [`Telegram feature status`](./docs/telegram-surface.md#10-what-works-and-what-does-not) 為準。
+
+## 工具、Skills 與工作流程
+
+Core 將 agent 能力分成三層：
+
+1. **Level 1**：`bash`、檔案讀寫、search、patch、batch、subagent delegation 等 run-local tools。
+2. **Level 2**：由 HTTP tool server 提供的 web、surface、workflow、MCP、attachments、generation、SSH 等 callables。
+3. **Level 3**：從磁碟探索、按需載入的 `SKILL.md` bundles。
+
+建立並使用 `tools` CLI：
+
+```bash
+cd apps/tool-bridge
+bun run build
+./dist/index.js --list
+./dist/index.js --help workflow.run.list
+```
+
+連到其他 backend：
+
+```bash
+TOOL_SERVER_BACKEND_URL=http://host:8080 ./apps/tool-bridge/dist/index.js --list
+```
+
+外部 plugins 放在 `DATA_DIR/plugins/<plugin-id>/`。它們與 Core 在同一 process 中執行，具有 Core process 的權限；開發前請閱讀 [`PLUGIN_AUTHORING.md`](./PLUGIN_AUTHORING.md)。
+
+## Fork 專屬用法
+
+### 啟用 Telegram
+
+```yaml
+configVersion: 2
+
+surface:
+  telegram:
+    enabled: true
+    tokenEnv: TELEGRAM_BOT_TOKEN
+    allowedChatIds:
+      - "1001"
+```
+
+在 `.env` 設定 token，避免把 credential 留在 shell history：
+
+```dotenv
+TELEGRAM_BOT_TOKEN=replace-with-botfather-token
+```
+
+```bash
+docker compose up -d --wait --wait-timeout 120
+curl -s localhost:8080/readyz | jq '.checks[] | select(.name == "telegram.ready")'
+```
+
+群組 privacy mode、forum topic session IDs、streaming、command menu 與 troubleshooting 見 [`docs/telegram-surface.md`](./docs/telegram-surface.md)。
+
+### 路由圖像生成到相容 endpoint
+
+```yaml
+configVersion: 2
+
+tools:
+  generate:
+    image:
+      provider: openai-compatible
+```
+
+Docker Compose 請把 endpoint 與 credential 寫入已由 `compose.override.yaml` 載入的 `.env`：
+
+```dotenv
+OPENAI_COMPATIBLE_BASE_URL=https://provider.example.com/v1
+OPENAI_COMPATIBLE_API_KEY=replace-with-api-key
+```
+
+然後重建 container：
+
+```bash
+docker compose up -d --force-recreate --wait --wait-timeout 120 lilac
+```
+
+從 source 執行時，改為 `export` 同名變數後再啟動 Core。
+
+Alias、generation/edit endpoints、無 fallback 行為與 `aspectRatio` 限制見 [`docs/generate-image-openai-compatible.md`](./docs/generate-image-openai-compatible.md)。
+
+### 使用 custom-media plugin 範例
+
+```bash
+mkdir -p data/plugins
+cp -R examples/plugins/custom-media data/plugins/custom-media
+docker compose restart lilac
+docker compose up -d --wait --wait-timeout 120 lilac
+docker compose exec -T lilac /usr/local/bin/tools --operator --list
+docker compose exec -T lilac /usr/local/bin/tools --operator --help custom-media.image
+```
+
+完整 build、credential、model 與 file-safety contract 見 [`examples/plugins/custom-media/README.md`](./examples/plugins/custom-media/README.md)。
+
+## Operator CLI
+
+`lilac-acp` 可探索本機 ACP harness、搜尋或 snapshot sessions，並以 detached worker 執行 prompt。支援的 harness 取決於本機安裝與 discovery 結果。
+
+```bash
+cd apps/acp-controller
+bun run build
+./dist/index.js harnesses list
+./dist/index.js sessions list --directory /path/to/repo --search "failing tests"
+./dist/index.js prompt submit --directory /path/to/repo --harness opencode --text "Fix the failing tests"
+```
+
+狀態與取消命令見 [`apps/acp-controller/README.md`](./apps/acp-controller/README.md)。
 
 ## Repository Map
 
 | Path | Purpose |
 | --- | --- |
-| `apps/core/` | Main runtime process and supporting subsystems. |
-| `apps/tool-bridge/` | `tools` bridge CLI and standalone tool-server entrypoints. |
-| `apps/acp-controller/` | `lilac-acp` CLI for ACP harness operations. |
-| `packages/event-bus/` | Typed event spec and Redis Streams bus implementation. |
-| `packages/agent/` | AI SDK-based agent execution, streaming, and turn control. |
-| `packages/utils/` | Runtime config, model/provider resolution, prompts, and skill discovery. |
-| `packages/plugin-runtime/` | Shared plugin contract and runtime support. |
-| `data/` | Local runtime data and seeded config. |
-| `ref/` | Vendored/reference repos; treat as read-only. |
+| `apps/core/` | Redis-backed Core runtime 與所有 surface、workflow、tool wiring |
+| `apps/mini-lilac/` | 可安裝的 unified Mini Lilac command |
+| `apps/mini-lilac-server/` | Redis-free HTTP/SSE coding-agent server |
+| `apps/mini-lilac-tui/` | OpenTUI terminal client |
+| `apps/tool-bridge/` | `tools` CLI 與 standalone tool-server entrypoint |
+| `apps/acp-controller/` | `lilac-acp` multi-harness controller |
+| `packages/event-bus/` | Typed Redis Streams contract 與 transport |
+| `packages/agent/` | AI SDK streaming、steering、follow-up 與 interrupt control |
+| `packages/plugin-runtime/` | Level 1/Level 2 plugin contract |
+| `packages/mini-lilac-runtime/` | Mini sessions、transcripts、providers 與 tools |
+| `packages/mini-lilac-client/` | Mini wire protocol 與 reconnectable transport |
+| `packages/utils/` | Config、providers、prompts 與 Skills |
+| `data/` | Core 的 local runtime state；不要提交 secrets |
+| `ref/` | Vendored/reference repositories；依各自 license，視為 read-only |
 
-## Verified Commands
+## 開發與驗證
 
-### Workspace validation
+本 repo 使用 Bun workspaces：
 
 ```bash
 bun install
+bun run ci
+```
+
+`bun run ci` 會依序檢查 codegen、lint、root/workspace tests、TypeScript 與 formatting。常用的個別命令：
+
+```bash
 bun run test:all
-bun run lint
 bun run typecheck
+bun run lint
 bun run fmt:check
 ```
 
-### Build commands
+各 workspace 的 build、test 與 typecheck 命令見 [`AGENTS.md`](./AGENTS.md)；專案名詞與完整架構見 [`PROJECT.md`](./PROJECT.md)。
 
-```bash
-cd apps/tool-bridge && bun run build
-cd apps/acp-controller && bun run build
-```
+## Upstream 同步與支援邊界
 
-Remote runner build used by the core package:
+`.github/workflows/sync-upstream.yml` 每 6 小時檢查一次 upstream `main`，有新 commits 時嘗試 merge 到本 fork 的 `main`。乾淨合併後會觸發 image build；發生 conflict 時由維護者人工處理。
 
-```bash
-cd apps/core && bun run build:remote-runner
-```
+- 本 fork 新功能、部署 workflow、Telegram 或相容式圖像路由問題：請在 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono/issues) 回報。
+- 可在未修改 upstream 重現的問題：先確認 upstream 狀態，再向 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono/issues) 回報。
+- 歷史上由本 fork 回饋並已被 upstream 接收的功能，不再列為當前差異。清單見 [`docs/fork-differences.md`](./docs/fork-differences.md#已被上游接收的貢獻)。
 
-### ACP controller workflow
+## 文件
 
-```bash
-cd apps/acp-controller
-bun run build
-./dist/index.js --help
-./dist/index.js harnesses list
-./dist/index.js sessions list --directory /path/to/repo --search "failing tests"
-```
+從 [`docs/README.md`](./docs/README.md) 開始查找部署、surface、fork 功能與 extension 文件。
 
-### Containerized operator stack
+## License 與致謝
 
-```bash
-docker compose up --build
-```
+本 repository 依 [MIT License](./LICENSE) 發布，保留上游原作者的 copyright 與授權文字。
 
-This container path is real, but it is an operator workflow rather than a zero-config quick start. The runtime expects Redis plus runtime configuration such as surface credentials.
+感謝 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的原始設計與持續開發。本 fork 與上游維護者沒有從屬或官方背書關係。
 
-### `smart-search` runtime in the image
-
-The runtime container installs the official `@konbakuyomu/smart-search` npm package during image build. That package creates and manages its own isolated Python runtime as part of its upstream install flow, so the image does not need a custom wrapper layer for basic CLI availability.
-
-The image already includes the upstream prerequisites that `smart-search` expects, including `nodejs`, `npm`, `python3`, `python3-pip`, and `python3-venv`.
-
-Because the container sets `XDG_CONFIG_HOME=${DATA_DIR}/.config`, the default `smart-search` config path resolves inside the runtime data directory, typically:
-
-```bash
-/data/.config/smart-search/config.json
-```
-
-Useful checks inside the container:
-
-```bash
-smart-search --version
-smart-search doctor --format json
-smart-search setup
-```
-
-If you persist `/data`, the `smart-search` config and provider credentials persist with it.
-
-## Operational Prerequisites
-
-- The runtime expects **Redis** and reads seeded runtime config from `data/core-config.yaml`.
-- Discord uses `DISCORD_TOKEN` by default unless `surface.discord.tokenEnv` is changed in `core-config.yaml`.
-- Telegram is off by default. Set `surface.telegram.enabled: true` (requires `configVersion: 2`) and `TELEGRAM_BOT_TOKEN`; see `docs/telegram-surface.md`.
-- GitHub webhook ingress requires `GITHUB_WEBHOOK_SECRET`.
-- GitHub auth can be configured through user or app credentials, depending on the workflow.
-
-## Further Reading
-
-- [`PROJECT.md`](./PROJECT.md): architecture, terminology, and runtime flow
-- [`AGENTS.md`](./AGENTS.md): repo-specific coding and validation rules
-- [`apps/acp-controller/README.md`](./apps/acp-controller/README.md): ACP controller usage details
-- [`docs/telegram-surface.md`](./docs/telegram-surface.md): Telegram setup, allowlists, workflow authorization, verification, and troubleshooting
-- [`docs/generate-image-openai-compatible.md`](./docs/generate-image-openai-compatible.md): routing `generate.image` through an OpenAI-compatible provider
-
-### Runtime and deployment smoke commands
-
- - Docker/Compose (includes Redis): `docker compose up --build -d`
- - Verify a running deployment with the operator CLI: `bun run docker:verify`
- - Credential-free image smoke: `bun run docker:build --tag lilac:dev . && bun run docker:verify-image`
-- Docker deployment contract and diagnostics: `docs/docker-deployment.md`
-- Core runtime (needs `REDIS_URL` + Discord config): `bun apps/core/src/runtime/main.ts`
-  - Important: with default `core-config.yaml`, both Discord allowlists are empty, so the bot ignores all Discord traffic until you set at least one of `surface.discord.allowedChannelIds` or `surface.discord.allowedGuildIds`.
- - Tool server only (dev mode): `bun apps/tool-bridge/index.ts`
- - `tools` CLI (after building): `./apps/tool-bridge/dist/index.js --list`
-   - Target a different server with `TOOL_SERVER_BACKEND_URL=http://host:port`
-
-### Claude Subscription Provider
-
-Core can use Claude Code subscription authentication without an Anthropic API key. For a local run,
-install the official Claude tooling and use an existing authenticated config or run
-`claude auth login`, then select the credentialless provider in `core-config.yaml`:
-
-```yaml
-models:
-  main:
-    model: claude-code/claude-sonnet-4-6
-```
-
-Lilac does not read, store, or refresh the Claude credential. The provider delegates authentication
-to the official Claude runtime. Claude filesystem settings are disabled; run-scoped Lilac tools are
-exposed through an in-process MCP server. `batch` is intentionally omitted because Claude can issue
-independent MCP calls in parallel. This provider is distinct from the API-key-backed `anthropic`
-provider.
-
-Core's Docker image can use the Claude Agent SDK's bundled executable when no `claude` executable is
-on `PATH`. Operators may pass `CLAUDE_CODE_OAUTH_TOKEN`, mount an existing authenticated Claude
-config, or use both. Set `CLAUDE_CONFIG_DIR` to a non-empty absolute path that is writable by the
-`lilac` service user and backed by persistent storage; the stock Compose file does not configure
-Claude authentication or this mount automatically. See `docs/docker-deployment.md`.
-
-Eligible Claude agent sessions use Claude's native persisted transcripts for continuation across
-turns and process restarts. The first eligible call, or one with missing, invalid, compacted,
-scope-mismatched, or otherwise incompatible state, starts a fresh persisted session. Only an exact
-compatible continuation forks the last clean session; Lilac never advances that clean base in place.
-Native continuation is enabled only with exact proof:
-
-- Mini main sessions bind the exact selected history state, including states selected by undo/redo.
-- Mini named subagents persist under either a caller-supplied or returned generated `sessionName`.
-- Core named subagents require their stable continuation identity and an exact canonical
-  transcript hash/count.
-- Core primary continuation is limited to Discord. Its binding identifies the terminal request whose
-  retained transcript and lineage manifest prove the clean head, and the composed request must be an
-  exact complete-segment extension of that prefix.
-
-Missing, externally changed, incompatible, compacted, or otherwise unprovable native state starts a
-fresh persisted Claude session from Lilac's canonical history. Native Claude session IDs are
-operational details and are not exposed in normal user-facing output.
-
-Explicit model selection may cross between `claude-code` and another provider family at a new-turn
-boundary. The historical prefix is then replayed as lossy text: visible user/assistant text is kept,
-historical tool activity is labeled and bounded, and hidden reasoning, provider metadata, binary
-history, and executable historical tool protocol are dropped. In Core, automatic fallback never
-crosses a provider-family boundary, and automatic fallback is disabled entirely when the run starts
-on `claude-code`. Mini does not expose this Core model-fallback chain.
-
-Native transcripts are stored under `CLAUDE_CONFIG_DIR`, falling back to `~/.claude`, outside Lilac's
-SQLite/transcript stores. If explicitly set, it must be a non-empty absolute path. The directory must
-be writable, and must be mounted/persisted when continuation should survive container replacement.
-A dedicated directory separates operator-selected storage and retention, but is not an access-control
-or privacy boundary from Core, trusted tools, plugins, or other processes running as the same OS user.
-Native transcripts contain conversation data subject to Claude's own retention policy. Repeated exact
-continuations create retained forks and can make native storage grow roughly quadratically with
-conversation length. Attempt records are bounded. Core primary/named owners and Mini named children
-keep one current binding; Mini main bindings remain attached to retained history states
-and may grow with that history. Lilac does not delete Claude's native transcript files. Core
-revalidates primary terminal-request proof when a binding is read and retires stale bindings instead
-of resuming them. Its internal aggregate retention diagnostics report binding/attempt counts, orphan
-lineage metadata, unreferenced projections, total owned-blob bytes, and unreferenced owned-blob
-counts/bytes; they do not expose native Claude transcript contents.
-
-For direct Core `openai` or `codex` models, set `options.openai_server_compaction: true` to opt a
-model into OpenAI server compaction. This is model metadata and is never forwarded as an AI SDK
-provider option.
-
-Mini Lilac supports the same provider, declared in `providers.yaml`:
-
-```yaml
-providers:
-  claude-code:
-    type: claude-code
-    catalog: models-dev
-```
-
-It takes no `auth.json` entry (supplying one is a configuration error), no `baseUrl`, and requires
-`catalog: models-dev`. Models are resolved from Anthropic's models.dev metadata and filtered to the
-Claude families the CLI can launch. Two behaviors differ from other Mini Lilac providers:
-
-- Profiles that request `websearch` get Claude's built-in `WebSearch` instead of the API-key-backed
-  provider tool. Claude executes it, so it does not pass through Lilac approval, artifact capture, or
-  output normalization. It is the only profile-requested Claude built-in and is enabled only for
-  profiles that already ask for web search. Both Mini and Core also enable Claude's `ToolSearch` over
-  the deferred Lilac MCP tool catalog; Core enables no profile-requested built-ins.
-- Steering is injected into the live Claude query rather than waiting for a turn boundary. Messages
-  the query cannot take — attachments, or a steer sent before the query opened — stay queued and
-  behave as they do on any other provider.
-
-The published single-file `mini-lilac` command resolves an external `claude` executable from `PATH`;
-unlike the Core image, it cannot resolve the SDK optional executable from a bundled dependency tree.
-Local Mini runs may use `claude auth login` or existing authenticated config. A custom Mini container
-must install/mount that external CLI and provide authentication and persistent writable Claude config
-storage explicitly.
-
-## License
-
-This repository is licensed under MIT. See [`LICENSE`](./LICENSE) for details.
-
-The `ref/` directory contains vendored or reference material that keeps its own upstream license terms.
+`ref/` 內的 vendored/reference material 各自適用其原始授權條款。

--- a/apps/mini-lilac/README.md
+++ b/apps/mini-lilac/README.md
@@ -4,18 +4,20 @@ The installable Mini Lilac command. It bundles the terminal client and server be
 entry point:
 
 ```sh
-mini-lilac                         # terminal client
-mini-lilac tui --session <id>      # explicit terminal client
-mini-lilac server                  # server
-mini-lilac server auth codex       # server administration
+./dist/main.js                         # terminal client
+./dist/main.js tui --session <id>      # explicit terminal client
+./dist/main.js server                  # server
+./dist/main.js server auth codex       # server administration
 ```
 
-Install it with Bun or npm. Bun remains the runtime because the server uses Bun APIs:
+The package is not currently published to the public npm registry. Build the current checkout with
+Bun, which remains the runtime because the server uses Bun APIs:
 
 ```sh
-bun add --global @stanley2058/mini-lilac
-# or
-npm install --global @stanley2058/mini-lilac
+bun install --frozen-lockfile
+cd apps/mini-lilac
+bun run build
+./dist/main.js --help
 ```
 
 ## First Run
@@ -23,21 +25,21 @@ npm install --global @stanley2058/mini-lilac
 Create the default server configuration, authenticate with Codex, and start the server:
 
 ```sh
-mini-lilac server init
-mini-lilac server auth codex
-mini-lilac server
+./dist/main.js server init
+./dist/main.js server auth codex
+./dist/main.js server
 ```
 
 In another terminal, start the client from the workspace you want Mini Lilac to use:
 
 ```sh
 cd /path/to/your/project
-mini-lilac
+/path/to/lilac-mono/apps/mini-lilac/dist/main.js
 ```
 
 `server init` writes `config.yaml`, `providers.yaml`, and `auth.json` under
 `$XDG_STATE_HOME/mini-lilac` (or `~/.local/state/mini-lilac`). Existing files are skipped; use
-`mini-lilac server init --force` to replace them.
+`./dist/main.js server init --force` to replace them.
 
 Build and exercise the publication-ready package from this directory:
 
@@ -51,11 +53,9 @@ npm pack ./dist
 `bun run pack:npm` creates the npm tarball. `bun run publish:npm` publishes the staged `dist/`
 package, leaving workspace-only source, scripts, and dependencies out of the registry metadata.
 
-To build, pack, and globally reinstall the current checkout in one step:
-
-```sh
-bun run install:local
-```
+The `install:local` maintainer helper currently assumes an older `npm pack --json` output shape and
+is not a supported installation path with npm 12. Use the direct built executable above until the
+package is published or the helper is updated.
 
 The client, server, their internal workspace dependencies, and the patched `@opentui/core`
 JavaScript are bundled into `dist/main.js`. `@opentui/core` remains a package dependency so the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# Lilac Documentation
+
+這裡收錄 root README 以外的操作與設計文件。首次使用請先閱讀 [`../README.md`](../README.md)，再依需求進入下列主題。
+
+## Fork 與架構
+
+| 文件 | 內容 |
+| --- | --- |
+| [`fork-differences.md`](./fork-differences.md) | 本 fork 與 upstream 的現行差異、限制、同步政策與已 upstreamed 貢獻 |
+| [`../PROJECT.md`](../PROJECT.md) | Core 與 Mini Lilac 的完整架構、名詞、資料流與設定模型 |
+| [`../MIGRATIONS.md`](../MIGRATIONS.md) | Core config 與儲存格式的 migration contract |
+
+## Deployment 與 Surfaces
+
+| 文件 | 內容 |
+| --- | --- |
+| [`docker-deployment.md`](./docker-deployment.md) | Docker/Compose、operator token、持久化、UID、安全邊界與診斷 |
+| [`telegram-surface.md`](./telegram-surface.md) | BotFather、allowlists、群組、forum topics、workflow、驗證與限制 |
+| [`github-reply-permalinks.md`](./github-reply-permalinks.md) | GitHub issue/PR body 與 comment reply permalink contract |
+
+## Generation 與 Extensions
+
+| 文件 | 內容 |
+| --- | --- |
+| [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md) | 將 `generate.image` 路由到 OpenAI-compatible endpoint |
+| [`../PLUGIN_AUTHORING.md`](../PLUGIN_AUTHORING.md) | Level 1/Level 2 external plugin contract、lifecycle 與權限 |
+| [`../examples/plugins/custom-media/README.md`](../examples/plugins/custom-media/README.md) | 可部署的 OpenAI-compatible image/video plugin 範例 |
+
+## Applications
+
+| 文件 | 內容 |
+| --- | --- |
+| [`../apps/mini-lilac/README.md`](../apps/mini-lilac/README.md) | Mini Lilac 安裝與 first run |
+| [`../apps/mini-lilac-server/README.md`](../apps/mini-lilac-server/README.md) | Mini server 設定、provider/auth、API 與 history recovery |
+| [`../apps/mini-lilac-tui/README.md`](../apps/mini-lilac-tui/README.md) | Mini TUI options、keyboard model 與 rendering |
+| [`../apps/acp-controller/README.md`](../apps/acp-controller/README.md) | `lilac-acp` build、session search 與 detached prompts |
+
+## Contributors
+
+| 文件 | 內容 |
+| --- | --- |
+| [`../AGENTS.md`](../AGENTS.md) | Repo commands、測試規則與 TypeScript conventions |
+| [`../packages/remote-fs-runner/README.md`](../packages/remote-fs-runner/README.md) | Core SSH tools 使用的 remote filesystem helper |
+
+> [!NOTE]
+> `plan/` 是設計與執行紀錄，`ref/` 是 read-only reference repositories。兩者都不是一般操作文件的入口。

--- a/docs/fork-differences.md
+++ b/docs/fork-differences.md
@@ -1,0 +1,110 @@
+# Fork Differences
+
+本文件描述 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono) 相對於 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的現行差異。
+
+比較基準為 2026-08-03 的 `main`：本 fork 已包含 upstream commit [`8f5fdec`](https://github.com/stanley2058/lilac-mono/commit/8f5fdec8266402560563885e901a4ffa6f40272b)，並在其上保留下列功能與維運修改。
+
+> [!IMPORTANT]
+> 這是維護文件，不是永久相容性承諾。Upstream sync 後，已被上游接收或不再存在的差異必須從本表移除或重新分類。
+
+## 現行 Fork-only 功能
+
+| 領域 | 差異 | 使用入口 | 限制或注意事項 |
+| --- | --- | --- | --- |
+| Telegram surface | 新增 DM、group、forum topic ingress；streamed HTML output；cancel、reaction、command menu、outbound attachments、workflow cards/actions 與 same-surface tools | [`telegram-surface.md`](./telegram-surface.md)、fork PR [#45](https://github.com/DF-wu/lilac-mono/pull/45) | 預設停用；沒有 inbound attachment bytes；僅 long polling；history 來自 local SQLite index |
+| OpenAI-compatible image routing | 以 v2 config 將所有既有 `generate.image` aliases 路由到單一 operator endpoint | [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md)、fork PR [#47](https://github.com/DF-wu/lilac-mono/pull/47) | 無 custom alias mapping、official-provider fallback 或 cross-provider retry；部分 aliases 的 `aspectRatio` 只產生 warning |
+| GitHub reply permalinks | `In reply to` 連結會指向指定 issue/PR body 或 comment anchor | [`github-reply-permalinks.md`](./github-reply-permalinks.md)、fork PR [#49](https://github.com/DF-wu/lilac-mono/pull/49) | Body target 需要 issue database ID；取不到時退回 thread URL |
+| Custom media plugin example | 提供 external Level 2 image/video plugin，使用 OpenAI-compatible image API 與 QuantumNous/new-api-compatible video flow | [`custom-media/README.md`](../examples/plugins/custom-media/README.md)、fork PR [#30](https://github.com/DF-wu/lilac-mono/pull/30) | Plugin 是 trusted in-process code；restricted callers 目前不能直接使用 external callables |
+| ACP controller reliability | Detached run 將 Linux zombie worker 視為已停止，cancel 時關閉 harness client 讓 worker settle | Commit [`91ef3fd`](https://github.com/DF-wu/lilac-mono/commit/91ef3fd6) | Zombie detection 為 Linux-specific；可用 harness 仍取決於本機 discovery |
+| Compatible-provider tool calls | Compatible provider 即使回傳 `other` 等非標準 finish reason，只要已解析出 local tool calls 仍會執行並保存結果 | Commit [`1c58e532`](https://github.com/DF-wu/lilac-mono/commit/1c58e532201ee51782c98c1d8b16086f6bf45c34) | 只信任已通過 parser 的 local tool calls；不會把任意 provider text 當成 tool invocation |
+| Container delivery | Build workflow 發布 `catalina`、`claudia`、SHA tags，`latest` 指向 `catalina`；image 另加入 `rsync` | [`build-image.yml`](../.github/workflows/build-image.yml)、[`Dockerfile`](../Dockerfile) | 目前兩個 tag 使用相同 Dockerfile user 與 UID；`CONTAINER_USER` build arg 未被 Dockerfile 使用，因此不是實際的 user variants |
+| Upstream maintenance | Scheduled workflow 每 6 小時 fetch upstream `main`，有新 commits 時嘗試 merge，成功後觸發 image build | [`sync-upstream.yml`](../.github/workflows/sync-upstream.yml) | Merge conflict 會使 workflow 失敗，必須人工整合與驗證 |
+
+## Telegram 現況
+
+Telegram 是目前最大的 fork-only product delta。已實作的主要路徑包括：
+
+- DMs、groups、supergroups 與 forum topics。
+- Mention/active routing、streamed edits、HTML rendering 與 4096-character chunking。
+- Reply context、cancel、typing indicators、reactions、custom commands 與 menu aliases。
+- Outbound attachments、workflow progress/actions、`waitForReply` 與 allowlist-bound surface tools。
+
+仍未實作或受平台限制的項目：
+
+- Inbound photo/document bytes 不會送入 model；caption 仍可觸發 request。追蹤於 [issue #42](https://github.com/DF-wu/lilac-mono/issues/42)。
+- 只有 long polling，沒有 webhook ingress。
+- 沒有 Telegram-native conversation search index、inline queries、business accounts 或 voice/video transcription。
+- Message history 只包含 bot 實際觀察或送出的內容，不是 Telegram 既有完整歷史。
+
+精確 feature matrix 與平台差異以 [`telegram-surface.md`](./telegram-surface.md#10-what-works-and-what-does-not) 為準。
+
+## 已被上游接收的貢獻
+
+以下能力目前存在於本 fork，但已不再構成 fork divergence：
+
+| 原始貢獻 | Upstream 狀態 | 分類方式 |
+| --- | --- | --- |
+| Configurable Exa web search provider | Upstream PR [#1](https://github.com/stanley2058/lilac-mono/pull/1) 已 merge | 視為 inherited upstream capability |
+| `TAVILY_API_BASE_URL` 與相關 normalization/docs | Upstream PR [#4](https://github.com/stanley2058/lilac-mono/pull/4)、[#5](https://github.com/stanley2058/lilac-mono/pull/5) 已 merge | 視為 inherited upstream capability |
+| GitHub agent-comment marker、safe trigger parsing 與 self-trigger loop prevention | Upstream PR [#13](https://github.com/stanley2058/lilac-mono/pull/13) 已 merge | 不列入 fork-only GitHub 差異 |
+
+## 不應列為現行差異
+
+- **Core runtime、Discord、GitHub webhook 基礎、event bus、workflows、tools、plugins、Mini Lilac**：它們主要來自 upstream。README 可以正常介紹，但不能歸功於本 fork。
+- **Architecture Atlas**：相關 workspace 與功能已完整 revert。
+- **Fork-specific Discord working-indicator defaults**：已回復 upstream defaults。
+- **舊 empty-reply feature flag**：已 revert 或由後續 upstream 行為取代。
+- **`smart-search` 基礎 runtime**：相關實作目前不存在於 tree，屬於 reverted/superseded 行為，不是現行 container capability。
+
+## 相容性與安全邊界
+
+本 fork 保留 upstream 的主要架構與 config migration policy，但新增功能可能需要 `configVersion: 2`。Greenfield changes 可能是 breaking changes；升級前請閱讀 [`../MIGRATIONS.md`](../MIGRATIONS.md)。
+
+下列機制是 guardrails 或 trusted execution，不是 hostile-code sandbox：
+
+- Core 與 Mini 的 Bash/filesystem checks。
+- Programmatic workflow policy。
+- External plugins 與 MCP stdio processes。
+- Tool server request capabilities。
+- Docker 內同 UID process 之間的 filesystem access。
+
+部署時請同時閱讀 [`docker-deployment.md`](./docker-deployment.md) 與 [`../PROJECT.md`](../PROJECT.md)。
+
+## Upstream Sync Policy
+
+```mermaid
+flowchart TD
+    Check[Scheduled or manual sync] --> Fetch[Fetch upstream main]
+    Fetch --> Behind{Fork behind upstream?}
+    Behind -->|No| Stop[No change]
+    Behind -->|Yes| Merge[Merge upstream main]
+    Merge --> Clean{Merge succeeds?}
+    Clean -->|Yes| Push[Push fork main]
+    Push --> Build[Trigger image build]
+    Clean -->|No| Manual[Resolve and validate manually]
+```
+
+同步原則：
+
+1. 保留 upstream commit history，以 merge 方式整合。
+2. Fork-only features 必須有獨立 tests 與文件，避免 sync 時只能依賴 commit message 猜測行為。
+3. Upstream 接收同等功能後，先比較 contract，再移除重複 patch 與本文件中的 fork-only claim。
+4. 發生 conflict 時不以忽略 tests 或直接覆蓋 fork behavior 的方式換取綠色 sync。
+
+## 更新本文件
+
+每次新增 fork-only feature 或完成大型 upstream sync 時，至少核對：
+
+```bash
+git fetch origin
+git fetch upstream
+git log --no-merges upstream/main..origin/main
+git diff --stat upstream/main..origin/main
+```
+
+分類時要區分：
+
+- **Fork-only**：目前 upstream 沒有同等 contract。
+- **Inherited**：直接來自 upstream。
+- **Upstream-accepted**：最初由 fork 貢獻，但現在兩邊都具備。
+- **Reverted/superseded**：不再存在，不應出現在 README feature list。


### PR DESCRIPTION
## Summary

- rewrite the root README as a verified Traditional Chinese maintained-fork guide
- add an indexed documentation entry point and evidence-backed fork difference inventory
- replace unpublished Mini Lilac registry instructions with the working source-build executable path
- document current Compose, surface-authentication, plugin, image-routing, and upstream-sync behavior

## Verification

- `bun run typecheck`
- `bun run lint:fix`
- `bun run fmt`
- GitHub Markdown API rendering for all changed documents
- Mermaid CLI 11.16.0 rendering for all three diagrams
- relative and external link validation
- Mini Lilac build and CLI help paths
- Compose environment injection and `--wait` support
- source-mode Redis loopback path (`PONG`)
- five-lane goal, QA, quality, security, and context review

## CI note

`bun run ci` reaches 1898 passing Core tests and one environment-sensitive failure in `executeRestrictedBash > rejects cwd outside the workspace instead of silently substituting it` because this isolated worktree lives under `/tmp`, which the restricted Bash implementation treats specially. The exact test passes from the normal `/home/df/workspace/lilac-mono` checkout.