### PR TITLE
docs: make English the canonical README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lilac Mono
 
 <p align="center">
-  <strong>面向 Discord、Telegram、GitHub 與本機終端的事件驅動 AI Agent Runtime</strong>
+  <strong>Event-driven AI Agent Runtime for Discord, Telegram, GitHub, and the local terminal</strong>
 </p>
 
 <p align="center">
@@ -12,44 +12,48 @@
 </p>
 
 <p align="center">
-  <a href="#選擇執行方式">選擇執行方式</a> ·
-  <a href="#本-fork-的主要差異">Fork 差異</a> ·
-  <a href="#快速開始">快速開始</a> ·
+  <strong>Language:</strong> <a href="./README.md">English (primary / canonical)</a> · <a href="./README.zh-TW.md">繁體中文 (translation)</a>
+</p>
+
+<p align="center">
+  <a href="#choose-your-runtime">Choose your runtime</a> ·
+  <a href="#fork-differences">Fork differences</a> ·
+  <a href="#quick-start">Quick start</a> ·
   <a href="#core-surfaces">Surfaces</a> ·
-  <a href="./docs/README.md">完整文件</a> ·
-  <a href="./PROJECT.md">架構細節</a>
+  <a href="./docs/README.md">Full documentation</a> ·
+  <a href="./PROJECT.md">Architecture details</a>
 </p>
 
 > [!IMPORTANT]
-> 這是以 Git history 與 `upstream` remote 持續追蹤 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的 downstream fork，不是上游官方發行版。本專案定期合併上游更新，同時維護 Telegram、相容式圖像路由、GitHub 回覆連結與部署自動化等獨立功能。
+> This is a downstream fork that continuously tracks [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) through Git history and the `upstream` remote. It is not an official upstream release. This project regularly merges upstream updates while maintaining independent Telegram, OpenAI-compatible image routing, GitHub reply permalink, and deployment automation features.
 
-Lilac 把平台訊息、路由、模型執行、工具、Skills 與可恢復工作流程放在同一套 runtime 中。Monorepo 內同時提供完整的 **Core** 服務，以及不需要 Redis 的本機 coding agent **Mini Lilac**。
+Lilac brings platform messaging, routing, model execution, tools, Skills, and recoverable workflows into one runtime. The monorepo provides both the full **Core** service and **Mini Lilac**, a local coding agent that does not require Redis.
 
-## 選擇執行方式
+## Choose Your Runtime
 
 | | Core | Mini Lilac |
 | --- | --- | --- |
-| 適合情境 | 長駐 bot、多平台協作、自動化與 durable workflows | 在本機專案中使用互動式 coding agent |
-| 入口 | Discord、Telegram、GitHub webhook、HTTP tool server | Terminal TUI、HTTP/SSE API |
-| 狀態儲存 | Redis Streams + SQLite + `DATA_DIR` | SQLite + `$XDG_STATE_HOME/mini-lilac` |
-| 主要依賴 | Bun、Redis；建議使用 Docker Compose | Bun 與系統 `flock`，不需要 Redis |
-| 開始方式 | 從本 repo 設定並啟動 Core | 從本 repo build 並直接執行 Mini Lilac |
+| Best for | Long-running bots, multi-platform collaboration, automation, and durable workflows | Using an interactive coding agent in a local project |
+| Entry points | Discord, Telegram, GitHub webhook, HTTP tool server | Terminal TUI, HTTP/SSE API |
+| State | Redis Streams + SQLite + `DATA_DIR` | SQLite + `$XDG_STATE_HOME/mini-lilac` |
+| Main dependencies | Bun, Redis; Docker Compose is recommended | Bun and system `flock`; Redis is not required |
+| Getting started | Configure and start Core from this repo | Build and run Mini Lilac directly from this repo |
 
-Mini Lilac 是上游持續發展的產品，本 fork 會隨上游同步。若你要部署聊天平台 bot 或工作流程服務，選 Core；若只要在終端操作本機專案，Mini Lilac 是較短的路徑。
+Mini Lilac is a product under active upstream development, and this fork syncs with upstream. Choose Core to deploy a chat-platform bot or workflow service; choose Mini Lilac for the shortest path to operating a local project from the terminal.
 
-## 本 Fork 的主要差異
+## Fork Differences
 
-以下只列出目前仍與上游不同的行為。完整依據、限制與已回饋上游的項目見 [`docs/fork-differences.md`](./docs/fork-differences.md)。
+The table below lists only behavior that still differs from upstream. For the full rationale, limitations, and items reported back upstream, see [`docs/fork-differences.md`](./docs/fork-differences.md).
 
-| 領域 | 本 fork 提供的差異 | 重要限制 |
+| Area | Difference provided by this fork | Important limitations |
 | --- | --- | --- |
-| Telegram surface | DMs、群組、forum topics、串流 HTML 回覆、取消、reaction、command menu、outbound attachments、workflow cards 與同 surface tools | 預設停用；沒有 inbound attachment bytes；僅 long polling |
-| OpenAI-compatible 圖像路由 | 將既有 `generate.image` aliases 統一路由到 operator 指定的 OpenAI-compatible endpoint | 僅 `configVersion: 2`；無自動 fallback 或自訂 alias mapping |
-| GitHub 回覆 UX | `In reply to` 可直接連到 issue/PR body 或指定 comment 的 canonical permalink | GitHub comment self-loop 防護已被上游接收，不再列為 fork-only |
-| Custom media plugin | 可部署的 Level 2 image/video plugin 範例，示範嚴格設定與檔案安全處理 | Plugin 是 trusted in-process code；restricted caller 目前不能使用 external callables |
-| 維運與交付 | 每 6 小時檢查 upstream、GHCR `catalina`/`claudia` tags、ACP detached-run 強化 | 自動合併發生衝突時仍需人工處理 |
+| Telegram surface | DMs, groups, forum topics, streaming HTML replies, cancellation, reactions, command menu, outbound attachments, workflow cards, and same-surface tools | Disabled by default; inbound attachment bytes are unavailable; long polling only |
+| OpenAI-compatible image routing | Routes the existing `generate.image` aliases through a single operator-specified OpenAI-compatible endpoint | `configVersion: 2` only; no automatic fallback or custom alias mapping |
+| GitHub reply UX | `In reply to` can link directly to an issue/PR body or a specified comment's canonical permalink | GitHub comment self-loop protection has been accepted upstream and is no longer fork-only |
+| Custom media plugin | Deployable Level 2 image/video plugin example demonstrating strict configuration and file-safety handling | The plugin is trusted in-process code; restricted callers currently cannot use external callables |
+| Operations and delivery | Upstream checks every 6 hours, GHCR `catalina`/`claudia` tags, and ACP detached-run hardening | Automatic merges still require manual handling when conflicts occur |
 
-## 架構概覽
+## Architecture Overview
 
 ### Core request flow
 
@@ -71,9 +75,9 @@ flowchart LR
     Workflow[Durable workflow engine] <--> Request
 ```
 
-Core 的平台 adapter 會把事件送入 typed bus。Router 建立或更新 request，agent runner 再使用模型、工具與 Skills 執行，最後由 output relay 將結果送回原 surface。GitHub webhook 可直接建立 request。
+Core platform adapters send events to the typed bus. The router creates or updates a request, and the agent runner executes it using models, tools, and Skills. The output relay then sends the result back to the originating surface. GitHub webhooks can create requests directly.
 
-Durable workflow engine 使用相同 request bus，並以 SQLite journal 保存 trigger、wait、sleep、subagent 與恢復資訊。完整 topic、queue mode、權限與啟停順序見 [`PROJECT.md`](./PROJECT.md)。
+The durable workflow engine uses the same request bus and stores trigger, wait, sleep, subagent, and recovery information in a SQLite journal. See [`PROJECT.md`](./PROJECT.md) for the complete topics, queue modes, permissions, and startup/shutdown order.
 
 ### Fork maintenance flow
 
@@ -86,11 +90,11 @@ flowchart LR
     Fork --> Images[GHCR image workflow]
 ```
 
-## 快速開始
+## Quick Start
 
-### Mini Lilac：本機 coding agent
+### Mini Lilac: Local Coding Agent
 
-Mini Lilac 是最短的互動式使用路徑。套件目前尚未發布到 public npm registry，請從 checkout build 並直接執行；Server 預設只監聽 `127.0.0.1:8090`，TUI 必須在真正的 terminal 中執行。
+Mini Lilac is the shortest path to interactive use. The package is not currently published to the public npm registry, so build it from a checkout and run it directly. The server listens on `127.0.0.1:8090` by default, and the TUI must run in a real terminal.
 
 ```bash
 git clone https://github.com/DF-wu/lilac-mono.git
@@ -104,24 +108,24 @@ bun run build
 ./dist/main.js server
 ```
 
-在另一個 terminal 中，進入要操作的專案：
+In another terminal, enter the project you want to operate on:
 
 ```bash
 cd /path/to/your/project
 /path/to/lilac-mono/apps/mini-lilac/dist/main.js
 ```
 
-確認 server：
+Check the server:
 
 ```bash
 curl -fsS http://127.0.0.1:8090/api/mini-lilac/healthz
 ```
 
-設定檔、provider、API key、Codex OAuth、遠端 listener 認證與 TUI 操作見 [`apps/mini-lilac/README.md`](./apps/mini-lilac/README.md) 與 [`apps/mini-lilac-server/README.md`](./apps/mini-lilac-server/README.md)。
+See [`apps/mini-lilac/README.md`](./apps/mini-lilac/README.md) and [`apps/mini-lilac-server/README.md`](./apps/mini-lilac-server/README.md) for configuration, providers, API keys, Codex OAuth, remote listener authentication, and TUI usage.
 
-### Core：Docker Compose
+### Core: Docker Compose
 
-需求：Docker Compose、Bun 1.3.14、有效的 `DISCORD_TOKEN`，以及至少一組符合 `models.main` 設定的 model provider credential。目前 Core 啟動時仍會連線 Discord；即使只使用 Telegram、GitHub 或 tool server，Discord token 仍是必要設定。各 surface 的 allowlist 依然採 fail-closed 設計。
+Requirements: Docker Compose, Bun 1.3.14, a valid `DISCORD_TOKEN`, and at least one model provider credential matching the `models.main` configuration. Core still connects to Discord at startup; the Discord token remains required even when using only Telegram, GitHub, or the tool server. All surface allowlists remain fail-closed.
 
 ```bash
 git clone https://github.com/DF-wu/lilac-mono.git
@@ -141,10 +145,10 @@ services:
 YAML
 ```
 
-啟動前請完成兩件事：
+Before starting, complete these two steps:
 
-1. 在 `.env` 設定 `DISCORD_TOKEN` 與 `data/core-config.yaml` 所選 model provider 的 credential。Stock `compose.yaml` 不會傳入 provider credentials；上面的 `compose.override.yaml` 透過 `env_file` 明確傳入 `.env`。
-2. 在 `data/core-config.yaml` 設定 Discord allowlist，並啟用與限制其他要使用的 surface。
+1. Set `DISCORD_TOKEN` and the credential for the model provider selected in `data/core-config.yaml` in `.env`. Stock `compose.yaml` does not pass provider credentials; the `compose.override.yaml` above explicitly passes `.env` through `env_file`.
+2. Configure the Discord allowlist in `data/core-config.yaml`, and enable and restrict any other surfaces you plan to use.
 
 ```bash
 docker compose up -d --build --wait --wait-timeout 120
@@ -153,14 +157,14 @@ docker compose ps
 curl -fsS http://localhost:8080/readyz
 ```
 
-`compose.yaml` 同時啟動 Redis，並把 `./data` 掛載到 `/data`。正式部署、operator token、UID、持久化與診斷方式見 [`docs/docker-deployment.md`](./docs/docker-deployment.md)。
+`compose.yaml` also starts Redis and mounts `./data` at `/data`. See [`docs/docker-deployment.md`](./docs/docker-deployment.md) for production deployment, operator tokens, UID, persistence, and diagnostics.
 
 > [!WARNING]
-> Core tool server 沒有一般用途的 public HTTP authentication。請將 `8080` 保留在可信任的主機或網路邊界，不要直接暴露到公網。
+> Core's tool server has no general-purpose public HTTP authentication. Keep `8080` on a trusted host or network boundary; do not expose it directly to the public internet.
 
-### Core：從 source 執行
+### Core: Run from Source
 
-先安裝 dependencies 並準備可連線的 Redis：
+Install the dependencies and prepare a reachable Redis instance:
 
 ```bash
 bun install
@@ -172,36 +176,36 @@ export LL_TOOL_SERVER_PORT=8080
 bun apps/core/src/runtime/main.ts
 ```
 
-Core 必須有 `REDIS_URL`、`DISCORD_TOKEN` 與有效的 model 設定。Telegram 與 GitHub 可以不啟用，但目前 Discord adapter 仍會在 Core 啟動時連線；Discord allowlist 可以保持空白以忽略所有 Discord traffic。
+Core requires `REDIS_URL`, `DISCORD_TOKEN`, and a valid model configuration. Telegram and GitHub may remain disabled, but the Discord adapter still connects when Core starts; leave the Discord allowlist empty to ignore all Discord traffic.
 
 ## Core Surfaces
 
-| Surface | 最低設定 | 預設保護 | 詳細文件 |
+| Surface | Minimum configuration | Default protection | Documentation |
 | --- | --- | --- | --- |
-| Discord | `DISCORD_TOKEN`；設定 `allowedChannelIds` 或 `allowedGuildIds` | 兩個 allowlist 都空時忽略所有 Discord traffic | [`core-config.example.yaml`](./packages/utils/config-templates/core-config.example.yaml) |
-| Telegram | `configVersion: 2`、`enabled: true`、`TELEGRAM_BOT_TOKEN`、`allowedChatIds` | 預設停用；空 chat allowlist 時忽略所有 chats | [`docs/telegram-surface.md`](./docs/telegram-surface.md) |
-| GitHub | GitHub App auth、`GITHUB_WEBHOOK_SECRET`、可被 GitHub 連到的 HTTPS/reverse proxy；user token 是可選的 preferred outbound identity | 沒有 GitHub App secret 時整個 surface 不啟動；signature 不符回傳 `401` | [`docs/github-reply-permalinks.md`](./docs/github-reply-permalinks.md) |
+| Discord | `DISCORD_TOKEN`; configure `allowedChannelIds` or `allowedGuildIds` | Ignores all Discord traffic when both allowlists are empty | [`core-config.example.yaml`](./packages/utils/config-templates/core-config.example.yaml) |
+| Telegram | `configVersion: 2`, `enabled: true`, `TELEGRAM_BOT_TOKEN`, `allowedChatIds` | Disabled by default; ignores all chats when the chat allowlist is empty | [`docs/telegram-surface.md`](./docs/telegram-surface.md) |
+| GitHub | GitHub App auth, `GITHUB_WEBHOOK_SECRET`, and an HTTPS/reverse proxy reachable by GitHub; a user token is an optional preferred outbound identity | The surface does not start without the GitHub App secret; returns `401` for an invalid signature | [`docs/github-reply-permalinks.md`](./docs/github-reply-permalinks.md) |
 
-GitHub webhook 預設監聽 port `8787`、path `/github/webhook`。Stock Compose 沒有轉送或公開 GitHub webhook 的環境與 port，因此 production deployment 必須自行補上 reverse proxy、environment 與 network wiring。
+The GitHub webhook listens on port `8787` and path `/github/webhook` by default. Stock Compose does not forward or expose the GitHub webhook environment and port, so production deployments must provide the reverse proxy, environment, and network wiring themselves.
 
-Webhook secret 只驗證 inbound request；目前 runtime 以 GitHub App secret 作為整個 surface 的啟用條件。先設定 App，再視需要加入 user token 作為 preferred outbound identity。可用 operator-only onboarding 查看兩者參數：
+The webhook secret only verifies inbound requests; the runtime currently uses the GitHub App secret as the condition for enabling the entire surface. Set up the App first, then add a user token as the preferred outbound identity if needed. Use operator-only onboarding to inspect both parameters:
 
 ```bash
 docker compose exec -T lilac /usr/local/bin/tools --operator --help onboarding.github_app
 docker compose exec -T lilac /usr/local/bin/tools --operator --help onboarding.github_user_token
 ```
 
-Telegram 支援完整對話路徑、workflow cards 與同 surface tools，但平台能力不等於 Discord。Inbound media、history、reaction 與 search 差異請以 [`Telegram feature status`](./docs/telegram-surface.md#10-what-works-and-what-does-not) 為準。
+Telegram supports the full conversation path, workflow cards, and same-surface tools, but its platform capabilities are not identical to Discord. See [`Telegram feature status`](./docs/telegram-surface.md#10-what-works-and-what-does-not) for differences in inbound media, history, reactions, and search.
 
-## 工具、Skills 與工作流程
+## Tools, Skills, and Workflows
 
-Core 將 agent 能力分成三層：
+Core divides agent capabilities into three levels:
 
-1. **Level 1**：`bash`、檔案讀寫、search、patch、batch、subagent delegation 等 run-local tools。
-2. **Level 2**：由 HTTP tool server 提供的 web、surface、workflow、MCP、attachments、generation、SSH 等 callables。
-3. **Level 3**：從磁碟探索、按需載入的 `SKILL.md` bundles。
+1. **Level 1**: Run-local tools such as `bash`, file I/O, search, patch, batch, and subagent delegation.
+2. **Level 2**: Callables provided by the HTTP tool server, including web, surface, workflow, MCP, attachments, generation, and SSH.
+3. **Level 3**: `SKILL.md` bundles discovered on disk and loaded on demand.
 
-建立並使用 `tools` CLI：
+Build and use the `tools` CLI:
 
 ```bash
 cd apps/tool-bridge
@@ -210,17 +214,17 @@ bun run build
 ./dist/index.js --help workflow.run.list
 ```
 
-連到其他 backend：
+Connect to another backend:
 
 ```bash
 TOOL_SERVER_BACKEND_URL=http://host:8080 ./apps/tool-bridge/dist/index.js --list
 ```
 
-外部 plugins 放在 `DATA_DIR/plugins/<plugin-id>/`。它們與 Core 在同一 process 中執行，具有 Core process 的權限；開發前請閱讀 [`PLUGIN_AUTHORING.md`](./PLUGIN_AUTHORING.md)。
+External plugins go in `DATA_DIR/plugins/<plugin-id>/`. They run in the same process as Core and have the Core process's permissions; read [`PLUGIN_AUTHORING.md`](./PLUGIN_AUTHORING.md) before developing one.
 
-## Fork 專屬用法
+## Fork-Specific Usage
 
-### 啟用 Telegram
+### Enable Telegram
 
 ```yaml
 configVersion: 2
@@ -233,7 +237,7 @@ surface:
       - "1001"
 ```
 
-在 `.env` 設定 token，避免把 credential 留在 shell history：
+Set the token in `.env` to avoid leaving the credential in shell history:
 
 ```dotenv
 TELEGRAM_BOT_TOKEN=replace-with-botfather-token
@@ -244,9 +248,9 @@ docker compose up -d --wait --wait-timeout 120
 curl -s localhost:8080/readyz | jq '.checks[] | select(.name == "telegram.ready")'
 ```
 
-群組 privacy mode、forum topic session IDs、streaming、command menu 與 troubleshooting 見 [`docs/telegram-surface.md`](./docs/telegram-surface.md)。
+See [`docs/telegram-surface.md`](./docs/telegram-surface.md) for group privacy mode, forum topic session IDs, streaming, the command menu, and troubleshooting.
 
-### 路由圖像生成到相容 endpoint
+### Route Image Generation to a Compatible Endpoint
 
 ```yaml
 configVersion: 2
@@ -257,24 +261,24 @@ tools:
       provider: openai-compatible
 ```
 
-Docker Compose 請把 endpoint 與 credential 寫入已由 `compose.override.yaml` 載入的 `.env`：
+For Docker Compose, put the endpoint and credential in `.env`, which is loaded by `compose.override.yaml`:
 
 ```dotenv
 OPENAI_COMPATIBLE_BASE_URL=https://provider.example.com/v1
 OPENAI_COMPATIBLE_API_KEY=replace-with-api-key
 ```
 
-然後重建 container：
+Then recreate the container:
 
 ```bash
 docker compose up -d --force-recreate --wait --wait-timeout 120 lilac
 ```
 
-從 source 執行時，改為 `export` 同名變數後再啟動 Core。
+When running from source, export the variables with the same names before starting Core.
 
-Alias、generation/edit endpoints、無 fallback 行為與 `aspectRatio` 限制見 [`docs/generate-image-openai-compatible.md`](./docs/generate-image-openai-compatible.md)。
+See [`docs/generate-image-openai-compatible.md`](./docs/generate-image-openai-compatible.md) for aliases, generation/edit endpoints, the absence of fallback behavior, and `aspectRatio` limitations.
 
-### 使用 custom-media plugin 範例
+### Use the Custom Media Plugin Example
 
 ```bash
 mkdir -p data/plugins
@@ -285,11 +289,11 @@ docker compose exec -T lilac /usr/local/bin/tools --operator --list
 docker compose exec -T lilac /usr/local/bin/tools --operator --help custom-media.image
 ```
 
-完整 build、credential、model 與 file-safety contract 見 [`examples/plugins/custom-media/README.md`](./examples/plugins/custom-media/README.md)。
+See [`examples/plugins/custom-media/README.md`](./examples/plugins/custom-media/README.md) for the complete build, credential, model, and file-safety contract.
 
 ## Operator CLI
 
-`lilac-acp` 可探索本機 ACP harness、搜尋或 snapshot sessions，並以 detached worker 執行 prompt。支援的 harness 取決於本機安裝與 discovery 結果。
+`lilac-acp` discovers local ACP harnesses, searches or snapshots sessions, and runs prompts through detached workers. Supported harnesses depend on local installation and discovery results.
 
 ```bash
 cd apps/acp-controller
@@ -299,37 +303,37 @@ bun run build
 ./dist/index.js prompt submit --directory /path/to/repo --harness opencode --text "Fix the failing tests"
 ```
 
-狀態與取消命令見 [`apps/acp-controller/README.md`](./apps/acp-controller/README.md)。
+See [`apps/acp-controller/README.md`](./apps/acp-controller/README.md) for status and cancellation commands.
 
 ## Repository Map
 
 | Path | Purpose |
 | --- | --- |
-| `apps/core/` | Redis-backed Core runtime 與所有 surface、workflow、tool wiring |
-| `apps/mini-lilac/` | 可安裝的 unified Mini Lilac command |
+| `apps/core/` | Redis-backed Core runtime and all surface, workflow, and tool wiring |
+| `apps/mini-lilac/` | Installable unified Mini Lilac command |
 | `apps/mini-lilac-server/` | Redis-free HTTP/SSE coding-agent server |
 | `apps/mini-lilac-tui/` | OpenTUI terminal client |
-| `apps/tool-bridge/` | `tools` CLI 與 standalone tool-server entrypoint |
+| `apps/tool-bridge/` | `tools` CLI and standalone tool-server entrypoint |
 | `apps/acp-controller/` | `lilac-acp` multi-harness controller |
-| `packages/event-bus/` | Typed Redis Streams contract 與 transport |
-| `packages/agent/` | AI SDK streaming、steering、follow-up 與 interrupt control |
+| `packages/event-bus/` | Typed Redis Streams contract and transport |
+| `packages/agent/` | AI SDK streaming, steering, follow-up, and interrupt control |
 | `packages/plugin-runtime/` | Level 1/Level 2 plugin contract |
-| `packages/mini-lilac-runtime/` | Mini sessions、transcripts、providers 與 tools |
-| `packages/mini-lilac-client/` | Mini wire protocol 與 reconnectable transport |
-| `packages/utils/` | Config、providers、prompts 與 Skills |
-| `data/` | Core 的 local runtime state；不要提交 secrets |
-| `ref/` | Vendored/reference repositories；依各自 license，視為 read-only |
+| `packages/mini-lilac-runtime/` | Mini sessions, transcripts, providers, and tools |
+| `packages/mini-lilac-client/` | Mini wire protocol and reconnectable transport |
+| `packages/utils/` | Config, providers, prompts, and Skills |
+| `data/` | Core local runtime state; do not commit secrets |
+| `ref/` | Vendored/reference repositories; subject to their respective licenses and treated as read-only |
 
-## 開發與驗證
+## Development and Verification
 
-本 repo 使用 Bun workspaces：
+This repo uses Bun workspaces:
 
 ```bash
 bun install
 bun run ci
 ```
 
-`bun run ci` 會依序檢查 codegen、lint、root/workspace tests、TypeScript 與 formatting。常用的個別命令：
+`bun run ci` checks codegen, lint, root/workspace tests, TypeScript, and formatting in sequence. Common individual commands:
 
 ```bash
 bun run test:all
@@ -338,24 +342,24 @@ bun run lint
 bun run fmt:check
 ```
 
-各 workspace 的 build、test 與 typecheck 命令見 [`AGENTS.md`](./AGENTS.md)；專案名詞與完整架構見 [`PROJECT.md`](./PROJECT.md)。
+See [`AGENTS.md`](./AGENTS.md) for each workspace's build, test, and typecheck commands; see [`PROJECT.md`](./PROJECT.md) for project terminology and the complete architecture.
 
-## Upstream 同步與支援邊界
+## Upstream Sync and Support Boundaries
 
-`.github/workflows/sync-upstream.yml` 每 6 小時檢查一次 upstream `main`，有新 commits 時嘗試 merge 到本 fork 的 `main`。乾淨合併後會觸發 image build；發生 conflict 時由維護者人工處理。
+`.github/workflows/sync-upstream.yml` checks upstream `main` every 6 hours and attempts to merge new commits into this fork's `main`. A clean merge triggers an image build; maintainers handle conflicts manually.
 
-- 本 fork 新功能、部署 workflow、Telegram 或相容式圖像路由問題：請在 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono/issues) 回報。
-- 可在未修改 upstream 重現的問題：先確認 upstream 狀態，再向 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono/issues) 回報。
-- 歷史上由本 fork 回饋並已被 upstream 接收的功能，不再列為當前差異。清單見 [`docs/fork-differences.md`](./docs/fork-differences.md#已被上游接收的貢獻)。
+- Report new fork features, deployment workflows, Telegram issues, or OpenAI-compatible image-routing issues in [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono/issues).
+- For an issue reproducible without fork modifications, first confirm the upstream state, then report it to [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono/issues).
+- Features historically contributed by this fork and accepted upstream are no longer listed as current differences. See [`docs/fork-differences.md`](./docs/fork-differences.md#已被上游接收的貢獻) for the list.
 
-## 文件
+## Documentation
 
-從 [`docs/README.md`](./docs/README.md) 開始查找部署、surface、fork 功能與 extension 文件。
+Start with [`docs/README.md`](./docs/README.md) to find deployment, surface, fork-feature, and extension documentation.
 
-## License 與致謝
+## License and Acknowledgements
 
-本 repository 依 [MIT License](./LICENSE) 發布，保留上游原作者的 copyright 與授權文字。
+This repository is released under the [MIT License](./LICENSE), retaining the original upstream authors' copyright and license text.
 
-感謝 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的原始設計與持續開發。本 fork 與上游維護者沒有從屬或官方背書關係。
+Thanks to [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) for the original design and continued development. This fork has no affiliation with or official endorsement from the upstream maintainers.
 
-`ref/` 內的 vendored/reference material 各自適用其原始授權條款。
+Vendored/reference material in `ref/` is subject to its original license terms.

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ See [`AGENTS.md`](./AGENTS.md) for each workspace's build, test, and typecheck c
 
 - Report new fork features, deployment workflows, Telegram issues, or OpenAI-compatible image-routing issues in [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono/issues).
 - For an issue reproducible without fork modifications, first confirm the upstream state, then report it to [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono/issues).
-- Features historically contributed by this fork and accepted upstream are no longer listed as current differences. See [`docs/fork-differences.md`](./docs/fork-differences.md#已被上游接收的貢獻) for the list.
+- Features historically contributed by this fork and accepted upstream are no longer listed as current differences. See [`docs/fork-differences.md`](./docs/fork-differences.md#accepted-upstream-contributions) for the list.
 
 ## Documentation
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -20,7 +20,7 @@
   <a href="#本-fork-的主要差異">Fork 差異</a> ·
   <a href="#快速開始">快速開始</a> ·
   <a href="#core-surfaces">Surfaces</a> ·
-  <a href="./docs/README.md">完整文件</a> ·
+  <a href="./docs/README.zh-TW.md">完整文件</a> ·
   <a href="./PROJECT.md">架構細節</a>
 </p>
 
@@ -43,7 +43,7 @@ Mini Lilac 是上游持續發展的產品，本 fork 會隨上游同步。若你
 
 ## 本 Fork 的主要差異
 
-以下只列出目前仍與上游不同的行為。完整依據、限制與已回饋上游的項目見 [`docs/fork-differences.md`](./docs/fork-differences.md)。
+以下只列出目前仍與上游不同的行為。完整依據、限制與已回饋上游的項目見 [`docs/fork-differences.zh-TW.md`](./docs/fork-differences.zh-TW.md)。
 
 | 領域 | 本 fork 提供的差異 | 重要限制 |
 | --- | --- | --- |
@@ -350,11 +350,11 @@ bun run fmt:check
 
 - 本 fork 新功能、部署 workflow、Telegram 或相容式圖像路由問題：請在 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono/issues) 回報。
 - 可在未修改 upstream 重現的問題：先確認 upstream 狀態，再向 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono/issues) 回報。
-- 歷史上由本 fork 回饋並已被 upstream 接收的功能，不再列為當前差異。清單見 [`docs/fork-differences.md`](./docs/fork-differences.md#已被上游接收的貢獻)。
+- 歷史上由本 fork 回饋並已被 upstream 接收的功能，不再列為當前差異。清單見 [`docs/fork-differences.zh-TW.md`](./docs/fork-differences.zh-TW.md#已被上游接收的貢獻)。
 
 ## 文件
 
-從 [`docs/README.md`](./docs/README.md) 開始查找部署、surface、fork 功能與 extension 文件。
+從 [`docs/README.zh-TW.md`](./docs/README.zh-TW.md) 開始查找部署、surface、fork 功能與 extension 文件。
 
 ## License 與致謝
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,365 @@
+# Lilac Mono
+
+<p align="center">
+  <strong>面向 Discord、Telegram、GitHub 與本機終端的事件驅動 AI Agent Runtime</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/DF-wu/lilac-mono/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/DF-wu/lilac-mono/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/stanley2058/lilac-mono"><img alt="Upstream" src="https://img.shields.io/badge/upstream-stanley2058%2Flilac--mono-6f42c1"></a>
+  <a href="./package.json"><img alt="Bun 1.3.14" src="https://img.shields.io/badge/Bun-1.3.14-14151a?logo=bun&logoColor=white"></a>
+  <a href="./LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-2ea44f"></a>
+</p>
+
+<p align="center">
+  <strong>語言：</strong> <a href="./README.md">English（主要／規範版本）</a> · <a href="./README.zh-TW.md">繁體中文（翻譯）</a>
+</p>
+
+<p align="center">
+  <a href="#選擇執行方式">選擇執行方式</a> ·
+  <a href="#本-fork-的主要差異">Fork 差異</a> ·
+  <a href="#快速開始">快速開始</a> ·
+  <a href="#core-surfaces">Surfaces</a> ·
+  <a href="./docs/README.md">完整文件</a> ·
+  <a href="./PROJECT.md">架構細節</a>
+</p>
+
+> [!IMPORTANT]
+> 這是以 Git history 與 `upstream` remote 持續追蹤 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的 downstream fork，不是上游官方發行版。本專案定期合併上游更新，同時維護 Telegram、相容式圖像路由、GitHub 回覆連結與部署自動化等獨立功能。
+
+Lilac 把平台訊息、路由、模型執行、工具、Skills 與可恢復工作流程放在同一套 runtime 中。Monorepo 內同時提供完整的 **Core** 服務，以及不需要 Redis 的本機 coding agent **Mini Lilac**。
+
+## 選擇執行方式
+
+| | Core | Mini Lilac |
+| --- | --- | --- |
+| 適合情境 | 長駐 bot、多平台協作、自動化與 durable workflows | 在本機專案中使用互動式 coding agent |
+| 入口 | Discord、Telegram、GitHub webhook、HTTP tool server | Terminal TUI、HTTP/SSE API |
+| 狀態儲存 | Redis Streams + SQLite + `DATA_DIR` | SQLite + `$XDG_STATE_HOME/mini-lilac` |
+| 主要依賴 | Bun、Redis；建議使用 Docker Compose | Bun 與系統 `flock`，不需要 Redis |
+| 開始方式 | 從本 repo 設定並啟動 Core | 從本 repo build 並直接執行 Mini Lilac |
+
+Mini Lilac 是上游持續發展的產品，本 fork 會隨上游同步。若你要部署聊天平台 bot 或工作流程服務，選 Core；若只要在終端操作本機專案，Mini Lilac 是較短的路徑。
+
+## 本 Fork 的主要差異
+
+以下只列出目前仍與上游不同的行為。完整依據、限制與已回饋上游的項目見 [`docs/fork-differences.md`](./docs/fork-differences.md)。
+
+| 領域 | 本 fork 提供的差異 | 重要限制 |
+| --- | --- | --- |
+| Telegram surface | DMs、群組、forum topics、串流 HTML 回覆、取消、reaction、command menu、outbound attachments、workflow cards 與同 surface tools | 預設停用；沒有 inbound attachment bytes；僅 long polling |
+| OpenAI-compatible 圖像路由 | 將既有 `generate.image` aliases 統一路由到 operator 指定的 OpenAI-compatible endpoint | 僅 `configVersion: 2`；無自動 fallback 或自訂 alias mapping |
+| GitHub 回覆 UX | `In reply to` 可直接連到 issue/PR body 或指定 comment 的 canonical permalink | GitHub comment self-loop 防護已被上游接收，不再列為 fork-only |
+| Custom media plugin | 可部署的 Level 2 image/video plugin 範例，示範嚴格設定與檔案安全處理 | Plugin 是 trusted in-process code；restricted caller 目前不能使用 external callables |
+| 維運與交付 | 每 6 小時檢查 upstream、GHCR `catalina`/`claudia` tags、ACP detached-run 強化 | 自動合併發生衝突時仍需人工處理 |
+
+## 架構概覽
+
+### Core request flow
+
+```mermaid
+flowchart LR
+    Discord[Discord] --> Bus[Typed Redis Streams bus]
+    Telegram[Telegram] --> Bus
+    Bus --> Router[Surface router]
+    GitHub[GitHub webhook] --> Request[Request queue]
+    Router --> Request
+    Request --> Agent[Agent runner]
+    Agent --> L1[Level 1 local tools]
+    Agent --> L2[Level 2 HTTP tools]
+    Agent --> Skills[Level 3 skills]
+    Agent --> Output[Request-scoped output]
+    Output --> Discord
+    Output --> Telegram
+    Output --> GitHub
+    Workflow[Durable workflow engine] <--> Request
+```
+
+Core 的平台 adapter 會把事件送入 typed bus。Router 建立或更新 request，agent runner 再使用模型、工具與 Skills 執行，最後由 output relay 將結果送回原 surface。GitHub webhook 可直接建立 request。
+
+Durable workflow engine 使用相同 request bus，並以 SQLite journal 保存 trigger、wait、sleep、subagent 與恢復資訊。完整 topic、queue mode、權限與啟停順序見 [`PROJECT.md`](./PROJECT.md)。
+
+### Fork maintenance flow
+
+```mermaid
+flowchart LR
+    Upstream[stanley2058/lilac-mono main] -->|scheduled check every 6 hours| Sync[Sync Upstream workflow]
+    Sync -->|clean merge| Fork[DF-wu/lilac-mono main]
+    Features[Fork features and fixes] --> Fork
+    Fork --> CI[CI]
+    Fork --> Images[GHCR image workflow]
+```
+
+## 快速開始
+
+### Mini Lilac：本機 coding agent
+
+Mini Lilac 是最短的互動式使用路徑。套件目前尚未發布到 public npm registry，請從 checkout build 並直接執行；Server 預設只監聽 `127.0.0.1:8090`，TUI 必須在真正的 terminal 中執行。
+
+```bash
+git clone https://github.com/DF-wu/lilac-mono.git
+cd lilac-mono
+bun install --frozen-lockfile
+cd apps/mini-lilac
+bun run build
+
+./dist/main.js server init
+./dist/main.js server auth codex
+./dist/main.js server
+```
+
+在另一個 terminal 中，進入要操作的專案：
+
+```bash
+cd /path/to/your/project
+/path/to/lilac-mono/apps/mini-lilac/dist/main.js
+```
+
+確認 server：
+
+```bash
+curl -fsS http://127.0.0.1:8090/api/mini-lilac/healthz
+```
+
+設定檔、provider、API key、Codex OAuth、遠端 listener 認證與 TUI 操作見 [`apps/mini-lilac/README.md`](./apps/mini-lilac/README.md) 與 [`apps/mini-lilac-server/README.md`](./apps/mini-lilac-server/README.md)。
+
+### Core：Docker Compose
+
+需求：Docker Compose、Bun 1.3.14、有效的 `DISCORD_TOKEN`，以及至少一組符合 `models.main` 設定的 model provider credential。目前 Core 啟動時仍會連線 Discord；即使只使用 Telegram、GitHub 或 tool server，Discord token 仍是必要設定。各 surface 的 allowlist 依然採 fail-closed 設計。
+
+```bash
+git clone https://github.com/DF-wu/lilac-mono.git
+cd lilac-mono
+bun install
+
+cp .env.example .env
+chmod 600 .env
+mkdir -p data
+cp packages/utils/config-templates/core-config.example.yaml data/core-config.yaml
+
+cat > compose.override.yaml <<'YAML'
+services:
+  lilac:
+    env_file:
+      - .env
+YAML
+```
+
+啟動前請完成兩件事：
+
+1. 在 `.env` 設定 `DISCORD_TOKEN` 與 `data/core-config.yaml` 所選 model provider 的 credential。Stock `compose.yaml` 不會傳入 provider credentials；上面的 `compose.override.yaml` 透過 `env_file` 明確傳入 `.env`。
+2. 在 `data/core-config.yaml` 設定 Discord allowlist，並啟用與限制其他要使用的 surface。
+
+```bash
+docker compose up -d --build --wait --wait-timeout 120
+bun run docker:verify
+docker compose ps
+curl -fsS http://localhost:8080/readyz
+```
+
+`compose.yaml` 同時啟動 Redis，並把 `./data` 掛載到 `/data`。正式部署、operator token、UID、持久化與診斷方式見 [`docs/docker-deployment.md`](./docs/docker-deployment.md)。
+
+> [!WARNING]
+> Core tool server 沒有一般用途的 public HTTP authentication。請將 `8080` 保留在可信任的主機或網路邊界，不要直接暴露到公網。
+
+### Core：從 source 執行
+
+先安裝 dependencies 並準備可連線的 Redis：
+
+```bash
+bun install
+docker run --rm -d --name lilac-source-redis -p 127.0.0.1:6380:6379 redis:7-alpine
+
+export REDIS_URL=redis://127.0.0.1:6380
+export DATA_DIR="$PWD/data"
+export LL_TOOL_SERVER_PORT=8080
+bun apps/core/src/runtime/main.ts
+```
+
+Core 必須有 `REDIS_URL`、`DISCORD_TOKEN` 與有效的 model 設定。Telegram 與 GitHub 可以不啟用，但目前 Discord adapter 仍會在 Core 啟動時連線；Discord allowlist 可以保持空白以忽略所有 Discord traffic。
+
+## Core Surfaces
+
+| Surface | 最低設定 | 預設保護 | 詳細文件 |
+| --- | --- | --- | --- |
+| Discord | `DISCORD_TOKEN`；設定 `allowedChannelIds` 或 `allowedGuildIds` | 兩個 allowlist 都空時忽略所有 Discord traffic | [`core-config.example.yaml`](./packages/utils/config-templates/core-config.example.yaml) |
+| Telegram | `configVersion: 2`、`enabled: true`、`TELEGRAM_BOT_TOKEN`、`allowedChatIds` | 預設停用；空 chat allowlist 時忽略所有 chats | [`docs/telegram-surface.md`](./docs/telegram-surface.md) |
+| GitHub | GitHub App auth、`GITHUB_WEBHOOK_SECRET`、可被 GitHub 連到的 HTTPS/reverse proxy；user token 是可選的 preferred outbound identity | 沒有 GitHub App secret 時整個 surface 不啟動；signature 不符回傳 `401` | [`docs/github-reply-permalinks.md`](./docs/github-reply-permalinks.md) |
+
+GitHub webhook 預設監聽 port `8787`、path `/github/webhook`。Stock Compose 沒有轉送或公開 GitHub webhook 的環境與 port，因此 production deployment 必須自行補上 reverse proxy、environment 與 network wiring。
+
+Webhook secret 只驗證 inbound request；目前 runtime 以 GitHub App secret 作為整個 surface 的啟用條件。先設定 App，再視需要加入 user token 作為 preferred outbound identity。可用 operator-only onboarding 查看兩者參數：
+
+```bash
+docker compose exec -T lilac /usr/local/bin/tools --operator --help onboarding.github_app
+docker compose exec -T lilac /usr/local/bin/tools --operator --help onboarding.github_user_token
+```
+
+Telegram 支援完整對話路徑、workflow cards 與同 surface tools，但平台能力不等於 Discord。Inbound media、history、reaction 與 search 差異請以 [`Telegram feature status`](./docs/telegram-surface.md#10-what-works-and-what-does-not) 為準。
+
+## 工具、Skills 與工作流程
+
+Core 將 agent 能力分成三層：
+
+1. **Level 1**：`bash`、檔案讀寫、search、patch、batch、subagent delegation 等 run-local tools。
+2. **Level 2**：由 HTTP tool server 提供的 web、surface、workflow、MCP、attachments、generation、SSH 等 callables。
+3. **Level 3**：從磁碟探索、按需載入的 `SKILL.md` bundles。
+
+建立並使用 `tools` CLI：
+
+```bash
+cd apps/tool-bridge
+bun run build
+./dist/index.js --list
+./dist/index.js --help workflow.run.list
+```
+
+連到其他 backend：
+
+```bash
+TOOL_SERVER_BACKEND_URL=http://host:8080 ./apps/tool-bridge/dist/index.js --list
+```
+
+外部 plugins 放在 `DATA_DIR/plugins/<plugin-id>/`。它們與 Core 在同一 process 中執行，具有 Core process 的權限；開發前請閱讀 [`PLUGIN_AUTHORING.md`](./PLUGIN_AUTHORING.md)。
+
+## Fork 專屬用法
+
+### 啟用 Telegram
+
+```yaml
+configVersion: 2
+
+surface:
+  telegram:
+    enabled: true
+    tokenEnv: TELEGRAM_BOT_TOKEN
+    allowedChatIds:
+      - "1001"
+```
+
+在 `.env` 設定 token，避免把 credential 留在 shell history：
+
+```dotenv
+TELEGRAM_BOT_TOKEN=replace-with-botfather-token
+```
+
+```bash
+docker compose up -d --wait --wait-timeout 120
+curl -s localhost:8080/readyz | jq '.checks[] | select(.name == "telegram.ready")'
+```
+
+群組 privacy mode、forum topic session IDs、streaming、command menu 與 troubleshooting 見 [`docs/telegram-surface.md`](./docs/telegram-surface.md)。
+
+### 路由圖像生成到相容 endpoint
+
+```yaml
+configVersion: 2
+
+tools:
+  generate:
+    image:
+      provider: openai-compatible
+```
+
+Docker Compose 請把 endpoint 與 credential 寫入已由 `compose.override.yaml` 載入的 `.env`：
+
+```dotenv
+OPENAI_COMPATIBLE_BASE_URL=https://provider.example.com/v1
+OPENAI_COMPATIBLE_API_KEY=replace-with-api-key
+```
+
+然後重建 container：
+
+```bash
+docker compose up -d --force-recreate --wait --wait-timeout 120 lilac
+```
+
+從 source 執行時，改為 `export` 同名變數後再啟動 Core。
+
+Alias、generation/edit endpoints、無 fallback 行為與 `aspectRatio` 限制見 [`docs/generate-image-openai-compatible.md`](./docs/generate-image-openai-compatible.md)。
+
+### 使用 custom-media plugin 範例
+
+```bash
+mkdir -p data/plugins
+cp -R examples/plugins/custom-media data/plugins/custom-media
+docker compose restart lilac
+docker compose up -d --wait --wait-timeout 120 lilac
+docker compose exec -T lilac /usr/local/bin/tools --operator --list
+docker compose exec -T lilac /usr/local/bin/tools --operator --help custom-media.image
+```
+
+完整 build、credential、model 與 file-safety contract 見 [`examples/plugins/custom-media/README.md`](./examples/plugins/custom-media/README.md)。
+
+## Operator CLI
+
+`lilac-acp` 可探索本機 ACP harness、搜尋或 snapshot sessions，並以 detached worker 執行 prompt。支援的 harness 取決於本機安裝與 discovery 結果。
+
+```bash
+cd apps/acp-controller
+bun run build
+./dist/index.js harnesses list
+./dist/index.js sessions list --directory /path/to/repo --search "failing tests"
+./dist/index.js prompt submit --directory /path/to/repo --harness opencode --text "Fix the failing tests"
+```
+
+狀態與取消命令見 [`apps/acp-controller/README.md`](./apps/acp-controller/README.md)。
+
+## Repository Map
+
+| Path | Purpose |
+| --- | --- |
+| `apps/core/` | Redis-backed Core runtime 與所有 surface、workflow、tool wiring |
+| `apps/mini-lilac/` | 可安裝的 unified Mini Lilac command |
+| `apps/mini-lilac-server/` | Redis-free HTTP/SSE coding-agent server |
+| `apps/mini-lilac-tui/` | OpenTUI terminal client |
+| `apps/tool-bridge/` | `tools` CLI 與 standalone tool-server entrypoint |
+| `apps/acp-controller/` | `lilac-acp` multi-harness controller |
+| `packages/event-bus/` | Typed Redis Streams contract 與 transport |
+| `packages/agent/` | AI SDK streaming、steering、follow-up 與 interrupt control |
+| `packages/plugin-runtime/` | Level 1/Level 2 plugin contract |
+| `packages/mini-lilac-runtime/` | Mini sessions、transcripts、providers 與 tools |
+| `packages/mini-lilac-client/` | Mini wire protocol 與 reconnectable transport |
+| `packages/utils/` | Config、providers、prompts 與 Skills |
+| `data/` | Core 的 local runtime state；不要提交 secrets |
+| `ref/` | Vendored/reference repositories；依各自 license，視為 read-only |
+
+## 開發與驗證
+
+本 repo 使用 Bun workspaces：
+
+```bash
+bun install
+bun run ci
+```
+
+`bun run ci` 會依序檢查 codegen、lint、root/workspace tests、TypeScript 與 formatting。常用的個別命令：
+
+```bash
+bun run test:all
+bun run typecheck
+bun run lint
+bun run fmt:check
+```
+
+各 workspace 的 build、test 與 typecheck 命令見 [`AGENTS.md`](./AGENTS.md)；專案名詞與完整架構見 [`PROJECT.md`](./PROJECT.md)。
+
+## Upstream 同步與支援邊界
+
+`.github/workflows/sync-upstream.yml` 每 6 小時檢查一次 upstream `main`，有新 commits 時嘗試 merge 到本 fork 的 `main`。乾淨合併後會觸發 image build；發生 conflict 時由維護者人工處理。
+
+- 本 fork 新功能、部署 workflow、Telegram 或相容式圖像路由問題：請在 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono/issues) 回報。
+- 可在未修改 upstream 重現的問題：先確認 upstream 狀態，再向 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono/issues) 回報。
+- 歷史上由本 fork 回饋並已被 upstream 接收的功能，不再列為當前差異。清單見 [`docs/fork-differences.md`](./docs/fork-differences.md#已被上游接收的貢獻)。
+
+## 文件
+
+從 [`docs/README.md`](./docs/README.md) 開始查找部署、surface、fork 功能與 extension 文件。
+
+## License 與致謝
+
+本 repository 依 [MIT License](./LICENSE) 發布，保留上游原作者的 copyright 與授權文字。
+
+感謝 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的原始設計與持續開發。本 fork 與上游維護者沒有從屬或官方背書關係。
+
+`ref/` 內的 vendored/reference material 各自適用其原始授權條款。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,46 +1,48 @@
 # Lilac Documentation
 
-這裡收錄 root README 以外的操作與設計文件。首次使用請先閱讀 [`../README.md`](../README.md)，再依需求進入下列主題。
+This index covers operational and design documentation beyond the root README. [`../README.md`](../README.md) is the repository's primary, canonical entry point. Read it first, then use the sections below to find detailed documentation.
 
-## Fork 與架構
+Language: [`English (primary / canonical)`](../README.md) · [`Traditional Chinese (translation)`](../README.zh-TW.md) · [`Traditional Chinese documentation index`](./README.zh-TW.md)
 
-| 文件 | 內容 |
+## Fork and Architecture
+
+| Document | Contents |
 | --- | --- |
-| [`fork-differences.md`](./fork-differences.md) | 本 fork 與 upstream 的現行差異、限制、同步政策與已 upstreamed 貢獻 |
-| [`../PROJECT.md`](../PROJECT.md) | Core 與 Mini Lilac 的完整架構、名詞、資料流與設定模型 |
-| [`../MIGRATIONS.md`](../MIGRATIONS.md) | Core config 與儲存格式的 migration contract |
+| [`fork-differences.md`](./fork-differences.md) | Current differences from upstream, limitations, sync policy, and upstreamed contributions |
+| [`../PROJECT.md`](../PROJECT.md) | Complete Core and Mini Lilac architecture, terminology, data flow, and configuration model |
+| [`../MIGRATIONS.md`](../MIGRATIONS.md) | Core configuration and storage-format migration contract |
 
-## Deployment 與 Surfaces
+## Deployment and Surfaces
 
-| 文件 | 內容 |
+| Document | Contents |
 | --- | --- |
-| [`docker-deployment.md`](./docker-deployment.md) | Docker/Compose、operator token、持久化、UID、安全邊界與診斷 |
-| [`telegram-surface.md`](./telegram-surface.md) | BotFather、allowlists、群組、forum topics、workflow、驗證與限制 |
-| [`github-reply-permalinks.md`](./github-reply-permalinks.md) | GitHub issue/PR body 與 comment reply permalink contract |
+| [`docker-deployment.md`](./docker-deployment.md) | Docker/Compose, operator tokens, persistence, UID, security boundaries, and diagnostics |
+| [`telegram-surface.md`](./telegram-surface.md) | BotFather, allowlists, groups, forum topics, workflows, verification, and limitations |
+| [`github-reply-permalinks.md`](./github-reply-permalinks.md) | GitHub issue/PR body and comment reply permalink contract |
 
-## Generation 與 Extensions
+## Generation and Extensions
 
-| 文件 | 內容 |
+| Document | Contents |
 | --- | --- |
-| [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md) | 將 `generate.image` 路由到 OpenAI-compatible endpoint |
-| [`../PLUGIN_AUTHORING.md`](../PLUGIN_AUTHORING.md) | Level 1/Level 2 external plugin contract、lifecycle 與權限 |
-| [`../examples/plugins/custom-media/README.md`](../examples/plugins/custom-media/README.md) | 可部署的 OpenAI-compatible image/video plugin 範例 |
+| [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md) | Route `generate.image` to an OpenAI-compatible endpoint |
+| [`../PLUGIN_AUTHORING.md`](../PLUGIN_AUTHORING.md) | Level 1/Level 2 external plugin contract, lifecycle, and permissions |
+| [`../examples/plugins/custom-media/README.md`](../examples/plugins/custom-media/README.md) | Deployable OpenAI-compatible image/video plugin example |
 
 ## Applications
 
-| 文件 | 內容 |
+| Document | Contents |
 | --- | --- |
-| [`../apps/mini-lilac/README.md`](../apps/mini-lilac/README.md) | Mini Lilac 安裝與 first run |
-| [`../apps/mini-lilac-server/README.md`](../apps/mini-lilac-server/README.md) | Mini server 設定、provider/auth、API 與 history recovery |
-| [`../apps/mini-lilac-tui/README.md`](../apps/mini-lilac-tui/README.md) | Mini TUI options、keyboard model 與 rendering |
-| [`../apps/acp-controller/README.md`](../apps/acp-controller/README.md) | `lilac-acp` build、session search 與 detached prompts |
+| [`../apps/mini-lilac/README.md`](../apps/mini-lilac/README.md) | Mini Lilac installation and first run |
+| [`../apps/mini-lilac-server/README.md`](../apps/mini-lilac-server/README.md) | Mini server configuration, providers/auth, API, and history recovery |
+| [`../apps/mini-lilac-tui/README.md`](../apps/mini-lilac-tui/README.md) | Mini TUI options, keyboard model, and rendering |
+| [`../apps/acp-controller/README.md`](../apps/acp-controller/README.md) | `lilac-acp` build, session search, and detached prompts |
 
 ## Contributors
 
-| 文件 | 內容 |
+| Document | Contents |
 | --- | --- |
-| [`../AGENTS.md`](../AGENTS.md) | Repo commands、測試規則與 TypeScript conventions |
-| [`../packages/remote-fs-runner/README.md`](../packages/remote-fs-runner/README.md) | Core SSH tools 使用的 remote filesystem helper |
+| [`../AGENTS.md`](../AGENTS.md) | Repository commands, test rules, and TypeScript conventions |
+| [`../packages/remote-fs-runner/README.md`](../packages/remote-fs-runner/README.md) | Remote filesystem helper used by Core SSH tools |
 
 > [!NOTE]
-> `plan/` 是設計與執行紀錄，`ref/` 是 read-only reference repositories。兩者都不是一般操作文件的入口。
+> `plan/` contains design and execution records. `ref/` contains read-only reference repositories. Neither is an entry point for general operational documentation.

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -8,7 +8,7 @@
 
 | 文件 | 內容 |
 | --- | --- |
-| [`fork-differences.md`](./fork-differences.md) | 本 fork 與 upstream 的現行差異、限制、同步政策與已 upstreamed 貢獻 |
+| [`fork-differences.zh-TW.md`](./fork-differences.zh-TW.md) | 本 fork 與 upstream 的現行差異、限制、同步政策與已 upstreamed 貢獻 |
 | [`../PROJECT.md`](../PROJECT.md) | Core 與 Mini Lilac 的完整架構、名詞、資料流與設定模型 |
 | [`../MIGRATIONS.md`](../MIGRATIONS.md) | Core config 與儲存格式的 migration contract |
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -1,0 +1,48 @@
+# Lilac Documentation
+
+這裡收錄 root README 以外的操作與設計文件。`README.md` 是本 repository 的規範入口與 canonical 文件；首次使用請先閱讀 [`../README.md`](../README.md)。繁體中文翻譯請見 [`../README.zh-TW.md`](../README.zh-TW.md)，再依需求進入下列主題。
+
+語言入口：[`English README (canonical)`](../README.md) · [`繁體中文翻譯`](../README.zh-TW.md)
+
+## Fork 與架構
+
+| 文件 | 內容 |
+| --- | --- |
+| [`fork-differences.md`](./fork-differences.md) | 本 fork 與 upstream 的現行差異、限制、同步政策與已 upstreamed 貢獻 |
+| [`../PROJECT.md`](../PROJECT.md) | Core 與 Mini Lilac 的完整架構、名詞、資料流與設定模型 |
+| [`../MIGRATIONS.md`](../MIGRATIONS.md) | Core config 與儲存格式的 migration contract |
+
+## Deployment 與 Surfaces
+
+| 文件 | 內容 |
+| --- | --- |
+| [`docker-deployment.md`](./docker-deployment.md) | Docker/Compose、operator token、持久化、UID、安全邊界與診斷 |
+| [`telegram-surface.md`](./telegram-surface.md) | BotFather、allowlists、群組、forum topics、workflow、驗證與限制 |
+| [`github-reply-permalinks.md`](./github-reply-permalinks.md) | GitHub issue/PR body 與 comment reply permalink contract |
+
+## Generation 與 Extensions
+
+| 文件 | 內容 |
+| --- | --- |
+| [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md) | 將 `generate.image` 路由到 OpenAI-compatible endpoint |
+| [`../PLUGIN_AUTHORING.md`](../PLUGIN_AUTHORING.md) | Level 1/Level 2 external plugin contract、lifecycle 與權限 |
+| [`../examples/plugins/custom-media/README.md`](../examples/plugins/custom-media/README.md) | 可部署的 OpenAI-compatible image/video plugin 範例 |
+
+## Applications
+
+| 文件 | 內容 |
+| --- | --- |
+| [`../apps/mini-lilac/README.md`](../apps/mini-lilac/README.md) | Mini Lilac 安裝與 first run |
+| [`../apps/mini-lilac-server/README.md`](../apps/mini-lilac-server/README.md) | Mini server 設定、provider/auth、API 與 history recovery |
+| [`../apps/mini-lilac-tui/README.md`](../apps/mini-lilac-tui/README.md) | Mini TUI options、keyboard model 與 rendering |
+| [`../apps/acp-controller/README.md`](../apps/acp-controller/README.md) | `lilac-acp` build、session search 與 detached prompts |
+
+## Contributors
+
+| 文件 | 內容 |
+| --- | --- |
+| [`../AGENTS.md`](../AGENTS.md) | Repo commands、測試規則與 TypeScript conventions |
+| [`../packages/remote-fs-runner/README.md`](../packages/remote-fs-runner/README.md) | Core SSH tools 使用的 remote filesystem helper |
+
+> [!NOTE]
+> `plan/` 是設計與執行紀錄，`ref/` 是 read-only reference repositories。兩者都不是一般操作文件的入口。

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -2,7 +2,7 @@
 
 這裡收錄 root README 以外的操作與設計文件。`README.md` 是本 repository 的規範入口與 canonical 文件；首次使用請先閱讀 [`../README.md`](../README.md)。繁體中文翻譯請見 [`../README.zh-TW.md`](../README.zh-TW.md)，再依需求進入下列主題。
 
-語言入口：[`English README (canonical)`](../README.md) · [`繁體中文翻譯`](../README.zh-TW.md)
+語言入口：[`English README (canonical)`](../README.md) · [`繁體中文翻譯`](../README.zh-TW.md) · [`English documentation index`](./README.md)
 
 ## Fork 與架構
 

--- a/docs/fork-differences.md
+++ b/docs/fork-differences.md
@@ -1,74 +1,76 @@
 # Fork Differences
 
-本文件描述 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono) 相對於 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的現行差異。
+Language: [`English (primary / canonical)`](./fork-differences.md) · [`Traditional Chinese (translation)`](./fork-differences.zh-TW.md)
 
-比較基準為 2026-08-03 的 `main`：本 fork 已包含 upstream commit [`8f5fdec`](https://github.com/stanley2058/lilac-mono/commit/8f5fdec8266402560563885e901a4ffa6f40272b)，並在其上保留下列功能與維運修改。
+This document describes the current differences between [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono) and [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono).
+
+The comparison baseline is `main` as of 2026-08-03: this fork includes upstream commit [`8f5fdec`](https://github.com/stanley2058/lilac-mono/commit/8f5fdec8266402560563885e901a4ffa6f40272b) and retains the following feature and operational changes on top of it.
 
 > [!IMPORTANT]
-> 這是維護文件，不是永久相容性承諾。Upstream sync 後，已被上游接收或不再存在的差異必須從本表移除或重新分類。
+> This is a maintenance document, not a permanent compatibility commitment. After an upstream sync, differences that have been accepted upstream or no longer exist must be removed from this table or reclassified.
 
-## 現行 Fork-only 功能
+## Current Fork-only Features
 
-| 領域 | 差異 | 使用入口 | 限制或注意事項 |
+| Area | Difference | Entry point | Limitations or considerations |
 | --- | --- | --- | --- |
-| Telegram surface | 新增 DM、group、forum topic ingress；streamed HTML output；cancel、reaction、command menu、outbound attachments、workflow cards/actions 與 same-surface tools | [`telegram-surface.md`](./telegram-surface.md)、fork PR [#45](https://github.com/DF-wu/lilac-mono/pull/45) | 預設停用；沒有 inbound attachment bytes；僅 long polling；history 來自 local SQLite index |
-| OpenAI-compatible image routing | 以 v2 config 將所有既有 `generate.image` aliases 路由到單一 operator endpoint | [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md)、fork PR [#47](https://github.com/DF-wu/lilac-mono/pull/47) | 無 custom alias mapping、official-provider fallback 或 cross-provider retry；部分 aliases 的 `aspectRatio` 只產生 warning |
-| GitHub reply permalinks | `In reply to` 連結會指向指定 issue/PR body 或 comment anchor | [`github-reply-permalinks.md`](./github-reply-permalinks.md)、fork PR [#49](https://github.com/DF-wu/lilac-mono/pull/49) | Body target 需要 issue database ID；取不到時退回 thread URL |
-| Custom media plugin example | 提供 external Level 2 image/video plugin，使用 OpenAI-compatible image API 與 QuantumNous/new-api-compatible video flow | [`custom-media/README.md`](../examples/plugins/custom-media/README.md)、fork PR [#30](https://github.com/DF-wu/lilac-mono/pull/30) | Plugin 是 trusted in-process code；restricted callers 目前不能直接使用 external callables |
-| ACP controller reliability | Detached run 將 Linux zombie worker 視為已停止，cancel 時關閉 harness client 讓 worker settle | Commit [`91ef3fd`](https://github.com/DF-wu/lilac-mono/commit/91ef3fd6) | Zombie detection 為 Linux-specific；可用 harness 仍取決於本機 discovery |
-| Compatible-provider tool calls | Compatible provider 即使回傳 `other` 等非標準 finish reason，只要已解析出 local tool calls 仍會執行並保存結果 | Commit [`1c58e532`](https://github.com/DF-wu/lilac-mono/commit/1c58e532201ee51782c98c1d8b16086f6bf45c34) | 只信任已通過 parser 的 local tool calls；不會把任意 provider text 當成 tool invocation |
-| Container delivery | Build workflow 發布 `catalina`、`claudia`、SHA tags，`latest` 指向 `catalina`；image 另加入 `rsync` | [`build-image.yml`](../.github/workflows/build-image.yml)、[`Dockerfile`](../Dockerfile) | 目前兩個 tag 使用相同 Dockerfile user 與 UID；`CONTAINER_USER` build arg 未被 Dockerfile 使用，因此不是實際的 user variants |
-| Upstream maintenance | Scheduled workflow 每 6 小時 fetch upstream `main`，有新 commits 時嘗試 merge，成功後觸發 image build | [`sync-upstream.yml`](../.github/workflows/sync-upstream.yml) | Merge conflict 會使 workflow 失敗，必須人工整合與驗證 |
+| Telegram surface | Adds DM, group, and forum topic ingress; streamed HTML output; cancellation, reactions, command menus, outbound attachments, workflow cards/actions, and same-surface tools | [`telegram-surface.md`](./telegram-surface.md), fork PR [#45](https://github.com/DF-wu/lilac-mono/pull/45) | Disabled by default; no inbound attachment bytes; long polling only; history comes from the local SQLite index |
+| OpenAI-compatible image routing | Uses v2 config to route all existing `generate.image` aliases to a single operator-specified endpoint | [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md), fork PR [#47](https://github.com/DF-wu/lilac-mono/pull/47) | No custom alias mapping, official-provider fallback, or cross-provider retry; `aspectRatio` produces only a warning for some aliases |
+| GitHub reply permalinks | `In reply to` links point to the specified issue/PR body or comment anchor | [`github-reply-permalinks.md`](./github-reply-permalinks.md), fork PR [#49](https://github.com/DF-wu/lilac-mono/pull/49) | Body targets require the issue database ID; falls back to the thread URL when unavailable |
+| Custom media plugin example | Provides an external Level 2 image/video plugin using an OpenAI-compatible image API and a QuantumNous/new-api-compatible video flow | [`custom-media/README.md`](../examples/plugins/custom-media/README.md), fork PR [#30](https://github.com/DF-wu/lilac-mono/pull/30) | Plugins are trusted in-process code; restricted callers currently cannot use external callables directly |
+| ACP controller reliability | Detached runs treat Linux zombie workers as stopped, and cancellation closes the harness client so the worker can settle | Commit [`91ef3fd`](https://github.com/DF-wu/lilac-mono/commit/91ef3fd6) | Zombie detection is Linux-specific; available harnesses still depend on local discovery |
+| Compatible-provider tool calls | When a compatible provider returns a nonstandard finish reason such as `other`, parsed local tool calls are still executed and their results preserved | Commit [`1c58e532`](https://github.com/DF-wu/lilac-mono/commit/1c58e532201ee51782c98c1d8b16086f6bf45c34) | Trusts only local tool calls that passed the parser; arbitrary provider text is not treated as a tool invocation |
+| Container delivery | The build workflow publishes `catalina`, `claudia`, and SHA tags, with `latest` pointing to `catalina`; the image also includes `rsync` | [`build-image.yml`](../.github/workflows/build-image.yml), [`Dockerfile`](../Dockerfile) | Both tags currently use the same Dockerfile user and UID; the Dockerfile does not use the `CONTAINER_USER` build arg, so these are not actual user variants |
+| Upstream maintenance | A scheduled workflow fetches upstream `main` every 6 hours, attempts a merge when new commits exist, and triggers an image build after a successful merge | [`sync-upstream.yml`](../.github/workflows/sync-upstream.yml) | Merge conflicts fail the workflow and require manual integration and validation |
 
-## Telegram 現況
+## Current Telegram Status
 
-Telegram 是目前最大的 fork-only product delta。已實作的主要路徑包括：
+Telegram is currently the largest fork-only product delta. The main implemented paths include:
 
-- DMs、groups、supergroups 與 forum topics。
-- Mention/active routing、streamed edits、HTML rendering 與 4096-character chunking。
-- Reply context、cancel、typing indicators、reactions、custom commands 與 menu aliases。
-- Outbound attachments、workflow progress/actions、`waitForReply` 與 allowlist-bound surface tools。
+- DMs, groups, supergroups, and forum topics.
+- Mention/active routing, streamed edits, HTML rendering, and 4096-character chunking.
+- Reply context, cancellation, typing indicators, reactions, custom commands, and menu aliases.
+- Outbound attachments, workflow progress/actions, `waitForReply`, and allowlist-bound surface tools.
 
-仍未實作或受平台限制的項目：
+Items that remain unimplemented or are constrained by the platform:
 
-- Inbound photo/document bytes 不會送入 model；caption 仍可觸發 request。追蹤於 [issue #42](https://github.com/DF-wu/lilac-mono/issues/42)。
-- 只有 long polling，沒有 webhook ingress。
-- 沒有 Telegram-native conversation search index、inline queries、business accounts 或 voice/video transcription。
-- Message history 只包含 bot 實際觀察或送出的內容，不是 Telegram 既有完整歷史。
+- Inbound photo/document bytes are not sent to the model; captions can still trigger a request. Tracked in [issue #42](https://github.com/DF-wu/lilac-mono/issues/42).
+- Only long polling is supported; there is no webhook ingress.
+- There is no Telegram-native conversation search index, inline query support, business account support, or voice/video transcription.
+- Message history includes only content the bot actually observed or sent, not Telegram's complete pre-existing history.
 
-精確 feature matrix 與平台差異以 [`telegram-surface.md`](./telegram-surface.md#10-what-works-and-what-does-not) 為準。
+See [`telegram-surface.md`](./telegram-surface.md#10-what-works-and-what-does-not) for the precise feature matrix and platform differences.
 
-## 已被上游接收的貢獻
+## Accepted Upstream Contributions
 
-以下能力目前存在於本 fork，但已不再構成 fork divergence：
+The following capabilities currently exist in this fork but no longer constitute fork divergence:
 
-| 原始貢獻 | Upstream 狀態 | 分類方式 |
+| Original contribution | Upstream status | Classification |
 | --- | --- | --- |
-| Configurable Exa web search provider | Upstream PR [#1](https://github.com/stanley2058/lilac-mono/pull/1) 已 merge | 視為 inherited upstream capability |
-| `TAVILY_API_BASE_URL` 與相關 normalization/docs | Upstream PR [#4](https://github.com/stanley2058/lilac-mono/pull/4)、[#5](https://github.com/stanley2058/lilac-mono/pull/5) 已 merge | 視為 inherited upstream capability |
-| GitHub agent-comment marker、safe trigger parsing 與 self-trigger loop prevention | Upstream PR [#13](https://github.com/stanley2058/lilac-mono/pull/13) 已 merge | 不列入 fork-only GitHub 差異 |
+| Configurable Exa web search provider | Upstream PR [#1](https://github.com/stanley2058/lilac-mono/pull/1) has been merged | Treated as an inherited upstream capability |
+| `TAVILY_API_BASE_URL` and related normalization/docs | Upstream PRs [#4](https://github.com/stanley2058/lilac-mono/pull/4) and [#5](https://github.com/stanley2058/lilac-mono/pull/5) have been merged | Treated as an inherited upstream capability |
+| GitHub agent-comment marker, safe trigger parsing, and self-trigger loop prevention | Upstream PR [#13](https://github.com/stanley2058/lilac-mono/pull/13) has been merged | Not listed as a fork-only GitHub difference |
 
-## 不應列為現行差異
+## Items That Should Not Be Listed as Current Differences
 
-- **Core runtime、Discord、GitHub webhook 基礎、event bus、workflows、tools、plugins、Mini Lilac**：它們主要來自 upstream。README 可以正常介紹，但不能歸功於本 fork。
-- **Architecture Atlas**：相關 workspace 與功能已完整 revert。
-- **Fork-specific Discord working-indicator defaults**：已回復 upstream defaults。
-- **舊 empty-reply feature flag**：已 revert 或由後續 upstream 行為取代。
-- **`smart-search` 基礎 runtime**：相關實作目前不存在於 tree，屬於 reverted/superseded 行為，不是現行 container capability。
+- **Core runtime, Discord, GitHub webhook foundation, event bus, workflows, tools, plugins, and Mini Lilac**: these primarily come from upstream. The README may describe them normally, but they must not be credited to this fork.
+- **Architecture Atlas**: the related workspace and functionality have been fully reverted.
+- **Fork-specific Discord working-indicator defaults**: these have been restored to the upstream defaults.
+- **Old empty-reply feature flag**: this has been reverted or superseded by later upstream behavior.
+- **`smart-search` foundational runtime**: the relevant implementation is not currently present in the tree. It is reverted/superseded behavior, not a current container capability.
 
-## 相容性與安全邊界
+## Compatibility and Security Boundaries
 
-本 fork 保留 upstream 的主要架構與 config migration policy，但新增功能可能需要 `configVersion: 2`。Greenfield changes 可能是 breaking changes；升級前請閱讀 [`../MIGRATIONS.md`](../MIGRATIONS.md)。
+This fork retains the main upstream architecture and config migration policy, but new features may require `configVersion: 2`. Greenfield changes may be breaking changes; read [`../MIGRATIONS.md`](../MIGRATIONS.md) before upgrading.
 
-下列機制是 guardrails 或 trusted execution，不是 hostile-code sandbox：
+The following mechanisms are guardrails or trusted execution, not hostile-code sandboxes:
 
-- Core 與 Mini 的 Bash/filesystem checks。
-- Programmatic workflow policy。
-- External plugins 與 MCP stdio processes。
-- Tool server request capabilities。
-- Docker 內同 UID process 之間的 filesystem access。
+- Core and Mini Bash/filesystem checks.
+- Programmatic workflow policy.
+- External plugins and MCP stdio processes.
+- Tool server request capabilities.
+- Filesystem access between processes running under the same UID inside Docker.
 
-部署時請同時閱讀 [`docker-deployment.md`](./docker-deployment.md) 與 [`../PROJECT.md`](../PROJECT.md)。
+For deployment, also read [`docker-deployment.md`](./docker-deployment.md) and [`../PROJECT.md`](../PROJECT.md).
 
 ## Upstream Sync Policy
 
@@ -84,16 +86,16 @@ flowchart TD
     Clean -->|No| Manual[Resolve and validate manually]
 ```
 
-同步原則：
+Sync principles:
 
-1. 保留 upstream commit history，以 merge 方式整合。
-2. Fork-only features 必須有獨立 tests 與文件，避免 sync 時只能依賴 commit message 猜測行為。
-3. Upstream 接收同等功能後，先比較 contract，再移除重複 patch 與本文件中的 fork-only claim。
-4. 發生 conflict 時不以忽略 tests 或直接覆蓋 fork behavior 的方式換取綠色 sync。
+1. Preserve upstream commit history by integrating with merges.
+2. Fork-only features must have independent tests and documentation so their behavior does not have to be inferred from commit messages during a sync.
+3. After upstream accepts equivalent functionality, compare the contracts before removing the duplicate patch and its fork-only claim from this document.
+4. When conflicts occur, do not obtain a green sync by ignoring tests or directly overwriting fork behavior.
 
-## 更新本文件
+## Updating This Document
 
-每次新增 fork-only feature 或完成大型 upstream sync 時，至少核對：
+Whenever a fork-only feature is added or a major upstream sync is completed, run at least the following checks:
 
 ```bash
 git fetch origin
@@ -102,9 +104,9 @@ git log --no-merges upstream/main..origin/main
 git diff --stat upstream/main..origin/main
 ```
 
-分類時要區分：
+Distinguish among these classifications:
 
-- **Fork-only**：目前 upstream 沒有同等 contract。
-- **Inherited**：直接來自 upstream。
-- **Upstream-accepted**：最初由 fork 貢獻，但現在兩邊都具備。
-- **Reverted/superseded**：不再存在，不應出現在 README feature list。
+- **Fork-only**: upstream does not currently provide an equivalent contract.
+- **Inherited**: comes directly from upstream.
+- **Upstream-accepted**: originally contributed by the fork, but now available in both repositories.
+- **Reverted/superseded**: no longer exists and should not appear in the README feature list.

--- a/docs/fork-differences.zh-TW.md
+++ b/docs/fork-differences.zh-TW.md
@@ -1,0 +1,112 @@
+# Fork Differences
+
+語言：[`English（主要／規範版本）`](./fork-differences.md) · [`繁體中文（翻譯）`](./fork-differences.zh-TW.md)
+
+本文件描述 [`DF-wu/lilac-mono`](https://github.com/DF-wu/lilac-mono) 相對於 [`stanley2058/lilac-mono`](https://github.com/stanley2058/lilac-mono) 的現行差異。
+
+比較基準為 2026-08-03 的 `main`：本 fork 已包含 upstream commit [`8f5fdec`](https://github.com/stanley2058/lilac-mono/commit/8f5fdec8266402560563885e901a4ffa6f40272b)，並在其上保留下列功能與維運修改。
+
+> [!IMPORTANT]
+> 這是維護文件，不是永久相容性承諾。Upstream sync 後，已被上游接收或不再存在的差異必須從本表移除或重新分類。
+
+## 現行 Fork-only 功能
+
+| 領域 | 差異 | 使用入口 | 限制或注意事項 |
+| --- | --- | --- | --- |
+| Telegram surface | 新增 DM、group、forum topic ingress；streamed HTML output；cancel、reaction、command menu、outbound attachments、workflow cards/actions 與 same-surface tools | [`telegram-surface.md`](./telegram-surface.md)、fork PR [#45](https://github.com/DF-wu/lilac-mono/pull/45) | 預設停用；沒有 inbound attachment bytes；僅 long polling；history 來自 local SQLite index |
+| OpenAI-compatible image routing | 以 v2 config 將所有既有 `generate.image` aliases 路由到單一 operator endpoint | [`generate-image-openai-compatible.md`](./generate-image-openai-compatible.md)、fork PR [#47](https://github.com/DF-wu/lilac-mono/pull/47) | 無 custom alias mapping、official-provider fallback 或 cross-provider retry；部分 aliases 的 `aspectRatio` 只產生 warning |
+| GitHub reply permalinks | `In reply to` 連結會指向指定 issue/PR body 或 comment anchor | [`github-reply-permalinks.md`](./github-reply-permalinks.md)、fork PR [#49](https://github.com/DF-wu/lilac-mono/pull/49) | Body target 需要 issue database ID；取不到時退回 thread URL |
+| Custom media plugin example | 提供 external Level 2 image/video plugin，使用 OpenAI-compatible image API 與 QuantumNous/new-api-compatible video flow | [`custom-media/README.md`](../examples/plugins/custom-media/README.md)、fork PR [#30](https://github.com/DF-wu/lilac-mono/pull/30) | Plugin 是 trusted in-process code；restricted callers 目前不能直接使用 external callables |
+| ACP controller reliability | Detached run 將 Linux zombie worker 視為已停止，cancel 時關閉 harness client 讓 worker settle | Commit [`91ef3fd`](https://github.com/DF-wu/lilac-mono/commit/91ef3fd6) | Zombie detection 為 Linux-specific；可用 harness 仍取決於本機 discovery |
+| Compatible-provider tool calls | Compatible provider 即使回傳 `other` 等非標準 finish reason，只要已解析出 local tool calls 仍會執行並保存結果 | Commit [`1c58e532`](https://github.com/DF-wu/lilac-mono/commit/1c58e532201ee51782c98c1d8b16086f6bf45c34) | 只信任已通過 parser 的 local tool calls；不會把任意 provider text 當成 tool invocation |
+| Container delivery | Build workflow 發布 `catalina`、`claudia`、SHA tags，`latest` 指向 `catalina`；image 另加入 `rsync` | [`build-image.yml`](../.github/workflows/build-image.yml)、[`Dockerfile`](../Dockerfile) | 目前兩個 tag 使用相同 Dockerfile user 與 UID；`CONTAINER_USER` build arg 未被 Dockerfile 使用，因此不是實際的 user variants |
+| Upstream maintenance | Scheduled workflow 每 6 小時 fetch upstream `main`，有新 commits 時嘗試 merge，成功後觸發 image build | [`sync-upstream.yml`](../.github/workflows/sync-upstream.yml) | Merge conflict 會使 workflow 失敗，必須人工整合與驗證 |
+
+## Telegram 現況
+
+Telegram 是目前最大的 fork-only product delta。已實作的主要路徑包括：
+
+- DMs、groups、supergroups 與 forum topics。
+- Mention/active routing、streamed edits、HTML rendering 與 4096-character chunking。
+- Reply context、cancel、typing indicators、reactions、custom commands 與 menu aliases。
+- Outbound attachments、workflow progress/actions、`waitForReply` 與 allowlist-bound surface tools。
+
+仍未實作或受平台限制的項目：
+
+- Inbound photo/document bytes 不會送入 model；caption 仍可觸發 request。追蹤於 [issue #42](https://github.com/DF-wu/lilac-mono/issues/42)。
+- 只有 long polling，沒有 webhook ingress。
+- 沒有 Telegram-native conversation search index、inline queries、business accounts 或 voice/video transcription。
+- Message history 只包含 bot 實際觀察或送出的內容，不是 Telegram 既有完整歷史。
+
+精確 feature matrix 與平台差異以 [`telegram-surface.md`](./telegram-surface.md#10-what-works-and-what-does-not) 為準。
+
+## 已被上游接收的貢獻
+
+以下能力目前存在於本 fork，但已不再構成 fork divergence：
+
+| 原始貢獻 | Upstream 狀態 | 分類方式 |
+| --- | --- | --- |
+| Configurable Exa web search provider | Upstream PR [#1](https://github.com/stanley2058/lilac-mono/pull/1) 已 merge | 視為 inherited upstream capability |
+| `TAVILY_API_BASE_URL` 與相關 normalization/docs | Upstream PR [#4](https://github.com/stanley2058/lilac-mono/pull/4)、[#5](https://github.com/stanley2058/lilac-mono/pull/5) 已 merge | 視為 inherited upstream capability |
+| GitHub agent-comment marker、safe trigger parsing 與 self-trigger loop prevention | Upstream PR [#13](https://github.com/stanley2058/lilac-mono/pull/13) 已 merge | 不列入 fork-only GitHub 差異 |
+
+## 不應列為現行差異
+
+- **Core runtime、Discord、GitHub webhook 基礎、event bus、workflows、tools、plugins、Mini Lilac**：它們主要來自 upstream。README 可以正常介紹，但不能歸功於本 fork。
+- **Architecture Atlas**：相關 workspace 與功能已完整 revert。
+- **Fork-specific Discord working-indicator defaults**：已回復 upstream defaults。
+- **舊 empty-reply feature flag**：已 revert 或由後續 upstream 行為取代。
+- **`smart-search` 基礎 runtime**：相關實作目前不存在於 tree，屬於 reverted/superseded 行為，不是現行 container capability。
+
+## 相容性與安全邊界
+
+本 fork 保留 upstream 的主要架構與 config migration policy，但新增功能可能需要 `configVersion: 2`。Greenfield changes 可能是 breaking changes；升級前請閱讀 [`../MIGRATIONS.md`](../MIGRATIONS.md)。
+
+下列機制是 guardrails 或 trusted execution，不是 hostile-code sandbox：
+
+- Core 與 Mini 的 Bash/filesystem checks。
+- Programmatic workflow policy。
+- External plugins 與 MCP stdio processes。
+- Tool server request capabilities。
+- Docker 內同 UID process 之間的 filesystem access。
+
+部署時請同時閱讀 [`docker-deployment.md`](./docker-deployment.md) 與 [`../PROJECT.md`](../PROJECT.md)。
+
+## Upstream Sync Policy
+
+```mermaid
+flowchart TD
+    Check[Scheduled or manual sync] --> Fetch[Fetch upstream main]
+    Fetch --> Behind{Fork behind upstream?}
+    Behind -->|No| Stop[No change]
+    Behind -->|Yes| Merge[Merge upstream main]
+    Merge --> Clean{Merge succeeds?}
+    Clean -->|Yes| Push[Push fork main]
+    Push --> Build[Trigger image build]
+    Clean -->|No| Manual[Resolve and validate manually]
+```
+
+同步原則：
+
+1. 保留 upstream commit history，以 merge 方式整合。
+2. Fork-only features 必須有獨立 tests 與文件，避免 sync 時只能依賴 commit message 猜測行為。
+3. Upstream 接收同等功能後，先比較 contract，再移除重複 patch 與本文件中的 fork-only claim。
+4. 發生 conflict 時不以忽略 tests 或直接覆蓋 fork behavior 的方式換取綠色 sync。
+
+## 更新本文件
+
+每次新增 fork-only feature 或完成大型 upstream sync 時，至少核對：
+
+```bash
+git fetch origin
+git fetch upstream
+git log --no-merges upstream/main..origin/main
+git diff --stat upstream/main..origin/main
+```
+
+分類時要區分：
+
+- **Fork-only**：目前 upstream 沒有同等 contract。
+- **Inherited**：直接來自 upstream。
+- **Upstream-accepted**：最初由 fork 貢獻，但現在兩邊都具備。
+- **Reverted/superseded**：不再存在，不應出現在 README feature list。


### PR DESCRIPTION
## Summary

- make the root README a complete English canonical project guide
- preserve the merged Traditional Chinese guide as `README.zh-TW.md`
- make the documentation index English-first while retaining `docs/README.zh-TW.md`
- add explicit language navigation across both entry points

## Verification

- `git diff --check`
- relative-link validation across all four README files
- byte-for-byte preservation of the merged Traditional Chinese root README, excluding the added language switch
- structural comparison of headings, warnings, fenced blocks, and original links